### PR TITLE
Add theme=light config option for light-background terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ colors
 # label_color=magenta   (red, green, yellow, blue, magenta, cyan, white)
 # separator=─           (character for the title separator)
 # shading=.,-~:;=!*#$@  (characters for 3D shading, supports UTF-8)
+# theme=light           (light or dark; light disables forced-bold and applies
+#                        per-color substitutions so the logo stays visible
+#                        on light terminal bgs)
+# light_white=38;5;18   (substitute for color 37 when theme=light; by default
+#                        only white is remapped. Each of light_black, light_red,
+#                        light_green, light_yellow, light_blue, light_magenta,
+#                        light_cyan, light_white can be set to override a color;
+#                        accepts names, bold-<name>, or raw SGR)
+# logo_outer=magenta    (override outer 3D logo color; useful when the logo
+#                        has no embedded colors, e.g. the built-in gentoo ASCII)
+# logo_inner=bold-white (override inner 3D logo color; same format as above)
 
 # 3d
 # light=top-left        (top-left, top-right, top, left, right, front, bottom-left, bottom-right)

--- a/fetch.c
+++ b/fetch.c
@@ -503,6 +503,17 @@ static char label_color[16] = "35"; // default magenta
 static char config_logo_outer[32] = "";
 static char config_logo_inner[32] = "";
 
+// Light-theme mode drops the forced-bold brightening in label and logo cell
+// rendering, and optionally substitutes any of the 8 base foreground colors
+// (30-37) with a darker color so bright variants stay visible on light
+// terminal backgrounds. By default only bright-white (37) is substituted.
+static int theme_is_light = 0;
+static char light_subs[8][32] = {
+    [7] = "\033[38;5;18m", // white -> deep navy
+};
+static const char *light_color_names[8] = {
+    "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"};
+
 // Parse a color spec ("name", "bold-<name>", or raw SGR params like "38;5;18")
 // into a full ANSI escape sequence stored in `out`.
 static void parse_color_spec(const char *val, char *out, size_t outsz) {
@@ -592,6 +603,23 @@ static void load_config(void) {
       continue;
 
     // Check for key=value settings
+    if (strncmp(line, "theme=", 6) == 0) {
+      theme_is_light = (strcmp(line + 6, "light") == 0);
+      continue;
+    }
+    if (strncmp(line, "light_", 6) == 0) {
+      char *eq = strchr(line + 6, '=');
+      if (eq) {
+        *eq = '\0';
+        for (int i = 0; i < 8; i++) {
+          if (strcmp(line + 6, light_color_names[i]) == 0) {
+            parse_color_spec(eq + 1, light_subs[i], sizeof(light_subs[i]));
+            break;
+          }
+        }
+        continue;
+      }
+    }
     if (strncmp(line, "logo_outer=", 11) == 0) {
       parse_color_spec(line + 11, config_logo_outer, sizeof(config_logo_outer));
       continue;
@@ -697,8 +725,8 @@ static void add_info(const char *label, const char *fmt, ...) {
   va_end(ap);
 
   char line[MAX_LINE_LEN];
-  snprintf(line, sizeof(line), "\033[1;%sm%s\033[0m: %s", label_color, label,
-           val);
+  snprintf(line, sizeof(line), "\033[%s%sm%s\033[0m: %s",
+           theme_is_light ? "" : "1;", label_color, label, val);
   add_line(line);
 }
 
@@ -716,8 +744,9 @@ static void gather_title(void) {
   gethostname(host, sizeof(host));
 
   char line[MAX_LINE_LEN];
-  snprintf(line, sizeof(line), "\033[1;%sm%s\033[0m@\033[1;%sm%s\033[0m",
-           label_color, user, label_color, host);
+  const char *bold = theme_is_light ? "" : "1;";
+  snprintf(line, sizeof(line), "\033[%s%sm%s\033[0m@\033[%s%sm%s\033[0m",
+           bold, label_color, user, bold, label_color, host);
   add_line(line);
 
   // separator
@@ -2044,9 +2073,17 @@ int main(int argc, char **argv) {
           } else {
             int c = colorbuf[i][j];
             if (c != prev_color) {
-              if (logo_has_ansi && c > 0)
-                printf("\033[1;%dm", c);
-              else
+              if (logo_has_ansi && c > 0) {
+                int idx = -1;
+                if (c >= 30 && c <= 37) idx = c - 30;
+                else if (c >= 90 && c <= 97) idx = c - 90;
+                if (theme_is_light && idx >= 0 && light_subs[idx][0])
+                  printf("%s", light_subs[idx]);
+                else if (theme_is_light)
+                  printf("\033[%dm", c);
+                else
+                  printf("\033[1;%dm", c);
+              } else
                 printf("%s", c == 1 ? color_inner : color_outer);
               prev_color = c;
             }

--- a/fetch.c
+++ b/fetch.c
@@ -499,6 +499,29 @@ static int field_enabled[F_COUNT];
 static int field_order[F_COUNT];
 static int field_count = 0;
 static char label_color[16] = "35"; // default magenta
+// Optional user overrides for the 3D logo colors (empty = use per-distro defaults).
+static char config_logo_outer[32] = "";
+static char config_logo_inner[32] = "";
+
+// Parse a color spec ("name", "bold-<name>", or raw SGR params like "38;5;18")
+// into a full ANSI escape sequence stored in `out`.
+static void parse_color_spec(const char *val, char *out, size_t outsz) {
+  int bold = 0;
+  if (strncmp(val, "bold-", 5) == 0) { bold = 1; val += 5; }
+  const char *code = NULL;
+  if      (strcmp(val, "black")   == 0) code = "30";
+  else if (strcmp(val, "red")     == 0) code = "31";
+  else if (strcmp(val, "green")   == 0) code = "32";
+  else if (strcmp(val, "yellow")  == 0) code = "33";
+  else if (strcmp(val, "blue")    == 0) code = "34";
+  else if (strcmp(val, "magenta") == 0) code = "35";
+  else if (strcmp(val, "cyan")    == 0) code = "36";
+  else if (strcmp(val, "white")   == 0) code = "37";
+  if (code)
+    snprintf(out, outsz, "\033[%s%sm", bold ? "1;" : "", code);
+  else
+    snprintf(out, outsz, "\033[%sm", val);
+}
 static int config_height = 0;     // 0 = auto (match info lines)
 static float size_scale = 1.0f;
 static float config_speed = 0.0f;    // 0 = use flag/default
@@ -569,6 +592,14 @@ static void load_config(void) {
       continue;
 
     // Check for key=value settings
+    if (strncmp(line, "logo_outer=", 11) == 0) {
+      parse_color_spec(line + 11, config_logo_outer, sizeof(config_logo_outer));
+      continue;
+    }
+    if (strncmp(line, "logo_inner=", 11) == 0) {
+      parse_color_spec(line + 11, config_logo_inner, sizeof(config_logo_inner));
+      continue;
+    }
     if (strncmp(line, "label_color=", 12) == 0) {
       char *val = line + 12;
       // Accept color names or numbers
@@ -1823,6 +1854,8 @@ int main(int argc, char **argv) {
 
   if (distro[0])
     set_distro_colors(distro);
+  if (config_logo_outer[0]) color_outer = config_logo_outer;
+  if (config_logo_inner[0]) color_inner = config_logo_inner;
 
   typedef void (*gather_fn)(void);
   gather_fn fns[F_COUNT] = {


### PR DESCRIPTION
## Summary

- Adds `theme=light` config option that makes the output readable on light terminal backgrounds
- Adds `logo_outer=` / `logo_inner=` config options to override the hardcoded per-distro 3D logo colors
- Fully backward-compatible — nothing changes unless the user opts in

## Motivation

On light-theme terminals the output has two readability problems:

1. Both label rendering and per-cell logo rendering hardcode a `\033[1;...m` prefix — forcing bold. Most palettes map bold to the bright-variant slot, so "bold blue" becomes bright-blue, often a pale washed-out tone on light bgs.
2. Several distro logos (including the built-in Gentoo one) embed ANSI color 37 (white), which renders as bright-white = invisible on light bgs.

There was no config path to fix this short of patching the source.

## What `theme=light` does

- Labels and per-cell logo colors are emitted without the forced `1;` bold prefix
- Any of the 8 base colors (30–37) can be substituted per-user:
  `light_black=`, `light_red=`, `light_green=`, `light_yellow=`,
  `light_blue=`, `light_magenta=`, `light_cyan=`, `light_white=`
  Only `light_white` is populated by default (`38;5;18`, deep navy).
- Default is still `theme=dark`, and the escape sequences emitted in that mode are byte-identical to before the patch.

## What `logo_outer=` / `logo_inner=` do

- Override the hardcoded per-distro outer/inner colors set in `set_distro_colors()`
- Empty by default, so existing setups are unaffected
- Useful both for light-theme tweaks and for anyone who wants a different palette without touching the code

All options accept color names (`red`, `blue`, …), `bold-<name>`, or raw SGR params (e.g. `38;5;18` for 256-color, `38;2;r;g;b` for truecolor).

## Example light-theme config

```
theme=light
label_color=38;5;18
logo_outer=black
logo_inner=38;5;18
light_white=38;5;18
light_magenta=black
```

## Test plan

- [x] `make` — clean build, no new warnings
- [x] Default behavior unchanged — with no config, emitted escapes match pre-patch (verified by diffing `script`-captured frames)
- [x] `theme=light` with Gentoo logo on a light terminal — no more bright-white or bright-magenta cells; labels render in configured color without forced bold
- [x] `logo_outer=black` / `logo_inner=blue` on a logo without embedded ANSI — colors come through as configured