### PR TITLE
Nix flake and home-manager options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,40 @@ sudo make install
 
 `PREFIX=~/.local make install` if you don't want it system-wide.
 
+### Nix Flake
+Add this repo to your ```flake.nix```. The package is built using the unstable channel. You can overwrite this by setting ```inputs.nixpkgs.follows = "nixpkgs"``` (if your default is 25.11).
+
+```nix
+inputs = {
+  ...
+areofyl-fetch.url = "github:areofyl/fetch";
+  ...
+}
+```
+#### Home-manager
+You also need to import the nix package in your ```home.nix```. Check ```nix/home-module.nix``` for the options. Most are the same but hyphens can not be used so camel-case has been used for those options instead.
+
+```nix
+{ pkgs, inputs, ... }: 
+
+{
+  import = [ inputs.areofyl-fetch.homeManagerModules.default ];
+  
+  programs.fetch = {
+    enable = true;
+    labelColor = "red";
+    info = [];
+    speed = 1.0;
+    spin = "xy";
+  };
+  
+}
+```
+
+#### Bugs
+* Because fastfetch is wrapped the ```terminal``` field will print: ".fetch-wrapped" on a kitty terminal.
+* GPU will not print full name, just generic "AMD GPU".
+
 ## Logos
 
 By default it auto-detects your distro and grabs the logo from fastfetch

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "Animated 3D fetch tool for your terminal";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";  # Can be overwritten in inputs with nixpkgs.follows
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs
+    }:
+
+    # Only tested on Linux x86_64
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.callPackage ./nix/package.nix { }; # Change this if repo author doesn't like the directory structure
+        }
+      );
+
+      overlays.default = final: prev: {
+        areofyl-fetch = final.callPackage ./nix/package.nix { }; # ... and this
+      };
+      # Make home-manager options available
+      homeManagerModules.default = import ./nix/home-module.nix; # ... and this :-)
+    };
+}

--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -1,0 +1,122 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.fetch;
+
+  infoFields = [
+    "os"
+    "host"
+    "kernel"
+    "uptime"
+    "packages"
+    "shell"
+    "display"
+    "wm"
+    "theme"
+    "icons"
+    "font"
+    "terminal"
+    "cpu"
+    "gpu"
+    "memory"
+    "swap"
+    "disk"
+    "ip"
+    "battery"
+    "locale"
+    "colors"
+  ];
+in {
+  options.programs.fetch = {
+    enable = lib.mkEnableOption "fetch";
+
+    info = lib.mkOption {
+      type = lib.types.listOf (lib.types.enum infoFields);
+      default = infoFields;
+      description = "Info fields to display, in order. Remove entries to hide them.";
+    };
+
+    labelColor = lib.mkOption {
+      type = lib.types.enum [
+        "red"
+        "green"
+        "yellow"
+        "blue"
+        "magenta"
+        "cyan"
+        "white"
+      ];
+      default = "magenta";
+      description = "Color used for info labels.";
+    };
+
+    separator = lib.mkOption {
+      type = lib.types.str;
+      default = "-";
+      description = "Character used for the title separator line.";
+    };
+
+    shading = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Characters used for 3D shading.";
+    };
+
+    light = lib.mkOption {
+      type = lib.types.nullOr (lib.types.enum [
+        "top-left" "top-right" "top" "left" "right" "front" "bottom-left" "bottom-right"
+      ]);
+      default = null;
+      description = "Light direction for 3D shading.";
+    };
+
+    spin = lib.mkOption {
+      type = lib.types.nullOr (lib.types.enum [ "x" "y" "xy" ]);
+      default = null;
+      description = "Rotation axis for the 3D animation.";
+    };
+
+    speed = lib.mkOption {
+      type = lib.types.nullOr lib.types.float;
+      default = null;
+      description = "Rotation speed.";
+    };
+
+    size = lib.mkOption {
+      type = lib.types.nullOr lib.types.float;
+      default = null;
+      description = "Logo scale";
+    };
+
+    height = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      description = "Override render height.";
+    };
+
+    extraConfig = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = "Extra lines";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ (pkgs.callPackage ./package.nix { }) ];
+
+    xdg.configFile."fetch/config".text = lib.concatStringsSep "\n" (
+      lib.filter (s: s != "") [
+        (lib.concatStringsSep "\n" cfg.info)
+        "label_color=${cfg.labelColor}"
+        "separator=${cfg.separator}"
+        (lib.optionalString (cfg.shading != null) "shading=${cfg.shading}")
+        (lib.optionalString (cfg.light != null)   "light=${cfg.light}")
+        (lib.optionalString (cfg.spin != null)    "spin=${cfg.spin}")
+        (lib.optionalString (cfg.speed != null)   "speed=${toString cfg.speed}")
+        (lib.optionalString (cfg.size != null)    "size=${toString cfg.size}")
+        (lib.optionalString (cfg.height != null)  "height=${toString cfg.height}")
+        cfg.extraConfig
+      ]
+    );
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitHub, fastfetch, makeWrapper }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fetch";
+  version = "1.0.0";
+
+# Uncomment to build locally
+# src = ../.;
+
+src = fetchFromGitHub {
+  owner = "areofyl";
+  repo = "fetch";
+  rev = "v${finalAttrs.version}";
+  hash = "sha256-rZr5ScxCr0L70LTpkntanDN46vjuqPGm2SMwqXewU0g=";
+};
+
+  # Install in nix/store
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  # Wrap fastfetch so it has the correct nix/store path
+  nativeBuildInputs = [ makeWrapper ];
+  postInstall = ''
+    wrapProgram $out/bin/fetch \
+      --prefix PATH : ${lib.makeBinPath [ fastfetch ]}
+  '';
+
+  meta = {
+    description = "Animated 3D fetch tool that renders your distro logo as a spinning bas-relief";
+    homepage = "https://github.com/areofyl/fetch";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ areofyl ];
+    mainProgram = "fetch";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This is a basic flake.nix to enable other Nix users to easily install and use fetch. Some problems that have occured on first install:

1. Terminal info field prints kitty as .fetch-wrapped. 
This only happens when fastfetch is installed and becaue it needs to be found in nix/store it must be wrapped. This causes the ```gather_terminal``` code which looks for the parent of TERM_PROGRAM kitty is found above this, an easy solution is just to config kitty to use ```env TERM_PROGRAM=kitty``` for an easy fix. 
2. GPU info field prints generic name.
3. There is no support for nix-darwin or any other archetype I will add it if someone can test it for me. I have only tested this on x86_64