### PR TITLE
Small fix for kitty, package.nix builds from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ You also need to import the nix package in your ```home.nix```. Check ```nix/hom
 }
 ```
 
-#### Bugs
-* Because fastfetch is wrapped the ```terminal``` field will print: ".fetch-wrapped" on a kitty terminal.
+#### Issues
 * GPU will not print full name, just generic "AMD GPU".
 
 ## Logos

--- a/fetch.c
+++ b/fetch.c
@@ -1351,6 +1351,8 @@ static void gather_terminal(void) {
   char *tp = getenv("TERM_PROGRAM");
   if (tp && tp[0]) {
     strncpy(term, tp, sizeof(term) - 1);
+  } else if (getenv("KITTY_WINDOW_ID")) {
+        strcpy(term, "kitty");
   } else {
     // Get parent process name (the terminal)
     FILE *fp = popen("ps -o comm= -p $(ps -o ppid= -p $$) 2>/dev/null", "r");

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -2,27 +2,23 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fetch";
-  version = "1.0.0";
+  version = "1.0.0-unstable-18-04-1";
+
 
 # Uncomment to build locally
-# src = ../.;
+src = ../.;
 
-src = fetchFromGitHub {
-  owner = "areofyl";
-  repo = "fetch";
-  rev = "v${finalAttrs.version}";
-  hash = "sha256-rZr5ScxCr0L70LTpkntanDN46vjuqPGm2SMwqXewU0g=";
-};
+# Uncomment and change rev and hash when upstream fix for kitty has been pushed
+#src = fetchFromGitHub {
+#  owner = "areofyl";
+#  repo = "fetch";
+#  rev = "a056f655a57611cba4f1076cfa40dbf360da164f";
+#  hash = "sha256-508QYmyPSKZisABowgyaRV93ZrkTiS3ziKBCcs3WOpQ=";
+#};
+
 
   # Install in nix/store
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
-
-  # Wrap fastfetch so it has the correct nix/store path
-  nativeBuildInputs = [ makeWrapper ];
-  postInstall = ''
-    wrapProgram $out/bin/fetch \
-      --prefix PATH : ${lib.makeBinPath [ fastfetch ]}
-  '';
 
   meta = {
     description = "Animated 3D fetch tool that renders your distro logo as a spinning bas-relief";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -20,6 +20,13 @@ src = ../.;
   # Install in nix/store
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
+  # Wrap fastfetch so it has the correct nix/store path
+  nativeBuildInputs = [ makeWrapper ];
+  postInstall = ''
+    wrapProgram $out/bin/fetch \
+    --prefix PATH : ${lib.makeBinPath [ fastfetch ]}
+  '';
+
   meta = {
     description = "Animated 3D fetch tool that renders your distro logo as a spinning bas-relief";
     homepage = "https://github.com/areofyl/fetch";


### PR DESCRIPTION
* The changes to fetch.c fixes the terminal to find kitty through KITTY_WINDOW_ID.
* package.nix must build from source as there is no commit with the kitty fix right now. I will update it when a new commit is available.
* updated README.md removing the issue with kitty terminal