### PR TITLE
fix(nix): use v-prefixed tag in fetchFromGitHub rev

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "areofyl";
     repo = "fetch";
-    rev = "${finalAttrs.version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-9ixx7XJcY4ktcN/lUfjvFljvHIEO2ktOebeGgL0ulHg=";
   };
 


### PR DESCRIPTION
## Summary

The `rev` in `nix/package.nix` was set to `"${finalAttrs.version}"` (e.g. `"2.1.0"`), but the actual git tag is `v2.1.0`. This causes a 404 when nix tries to fetch the source tarball:

```
trying https://github.com/areofyl/fetch/archive/2.1.0.tar.gz
curl: (22) The requested URL returned error: 404
```

Prefixing with `"v"` fixes the fetch.

## Change

```nix
- rev = "${finalAttrs.version}";
+ rev = "v${finalAttrs.version}";
```