### PR TITLE
Add COPR installation for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,18 @@ brew tap areofyl/fetch
 brew install fetch-git
 ```
 
-### Fedora Linux (RPM)
+### Fedora Linux
+You can install `fetch` from COPR:
 
 ```bash
+sudo dnf copr enable realorangekun/fetch
+sudo dnf install fetch
+```
+
+Or build an RPM package locally:
+
+```bash
+sudo dnf install @development-tools
 rpmbuild -ba fetch.spec
 sudo dnf install ~/rpmbuild/RPMS/*/fetch-*.rpm
 ```


### PR DESCRIPTION
Makes it easier for Fedora users to install fetch. Added a COPR repository so people can just run `sudo dnf copr enable realorangekun/fetch && sudo dnf install fetch` instead of building from source.

The COPR project auto-builds from this repo (the one forked) whenever changes are pushed, so it stays in sync. Local RPM build instructions are still there as a fallback for folks who want to build it themselves.