### PR TITLE
Add flatpak package count

### DIFF
--- a/fetch.c
+++ b/fetch.c
@@ -1091,6 +1091,23 @@ static void gather_packages(void) {
       snprintf(val, sizeof(val), "%d (apk)", n);
   }
 
+  n = 0;
+  FILE *flatpak_fp = popen("flatpak list --columns=ref 2>/dev/null", "r");
+  if (flatpak_fp) {
+    char buf[256];
+    while (fgets(buf, sizeof(buf), flatpak_fp))
+      n++;
+    pclose(flatpak_fp);
+  }
+  if (n > 0) {
+    char flatpak_val[32];
+    snprintf(flatpak_val, sizeof(flatpak_val), "%d (flatpak)", n);
+    if (val[0])
+      snprintf(val + strlen(val), sizeof(val) - strlen(val), ", %s", flatpak_val);
+    else
+      snprintf(val, sizeof(val), "%s", flatpak_val);
+  }
+
   if (val[0])
     add_info("Packages", "%s", val);
 }


### PR DESCRIPTION
The packages field only checked pacman, dpkg, rpm, xbps, and apk, so flatpak installs never showed up even though a lot of people rely on flatpak for apps. This adds a flatpak count alongside whatever system package manager gets detected, e.g. 2656 (dnf), 40 (flatpak).

Count comes from flatpak list, matching how fastfetch reports it.