### PR TITLE
fix: macOS support (battery segfault, Makefile install, cross-platform Nix)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ fetch: fetch.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)
 
 install: fetch
-	install -Dm755 fetch $(DESTDIR)$(PREFIX)/bin/fetch
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install -m 755 fetch $(DESTDIR)$(PREFIX)/bin/fetch
 
 clean:
 	rm -f fetch

--- a/fetch.c
+++ b/fetch.c
@@ -1983,15 +1983,15 @@ static void gather_battery(void) {
   if (!src) { CFRelease(sources); CFRelease(info); return; }
 
   int capacity = -1;
-  CFNumberRef capRef = CFDictionaryGetValue(src, kIOPSCurrentCapacityKey);
+  CFNumberRef capRef = CFDictionaryGetValue(src, CFSTR(kIOPSCurrentCapacityKey));
   if (capRef) CFNumberGetValue(capRef, kCFNumberIntType, &capacity);
 
   int isCharging = 0;
-  CFBooleanRef chgRef = CFDictionaryGetValue(src, kIOPSIsChargingKey);
+  CFBooleanRef chgRef = CFDictionaryGetValue(src, CFSTR(kIOPSIsChargingKey));
   if (chgRef) isCharging = CFBooleanGetValue(chgRef);
 
   int timeToEmpty = -1;
-  CFNumberRef tteRef = CFDictionaryGetValue(src, kIOPSTimeToEmptyKey);
+  CFNumberRef tteRef = CFDictionaryGetValue(src, CFSTR(kIOPSTimeToEmptyKey));
   if (tteRef) CFNumberGetValue(tteRef, kCFNumberIntType, &timeToEmpty);
 
   CFRelease(sources);

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,8 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
     in

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,45 +1,36 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
-  # linux dependencies
   makeWrapper,
   fastfetch,
+  # linux-only
   pciutils,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fetch";
-  version = "2.1.0";
+  version = "2.2.0";
   __structuredAttrs = true;
   strictDeps = true;
 
-  src = fetchFromGitHub {
-    owner = "areofyl";
-    repo = "fetch";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-9ixx7XJcY4ktcN/lUfjvFljvHIEO2ktOebeGgL0ulHg=";
-  };
+  src = lib.cleanSource ../.;
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
   nativeBuildInputs = [ makeWrapper ];
   postInstall = ''
     wrapProgram $out/bin/fetch \
     --prefix PATH : ${
-      lib.makeBinPath [
-        fastfetch
-        pciutils
-      ]
+      lib.makeBinPath ([ fastfetch ] ++ lib.optionals stdenv.hostPlatform.isLinux [ pciutils ])
     }
   '';
 
   meta = {
     description = "Animated 3D fetch tool that renders your distro logo as a spinning bas-relief";
     homepage = "https://github.com/areofyl/fetch";
-    changelog = "https://github.com/areofyl/fetch/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/areofyl/fetch/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ ghastrum ];
     mainProgram = "fetch";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
Makes fetch work correctly on macOS:

- **Battery segfault:** the `kIOPS*Key` macros are plain C strings, not `CFStringRef`, so passing them to `CFDictionaryGetValue` crashes in `objc_msgSend`. Wrapped in `CFSTR()`.
- **Makefile install:** `install -Dm755` is GNU-only; BSD `install` mangles it. Split into portable `install -d` + `install -m 755` (works on both).
- **Nix:** added the darwin systems, `platforms.unix`, and gated `pciutils` to Linux; the flake now builds from source so `nix build` reflects the repo on both platforms. Verified building and running on aarch64-darwin.