### PR TITLE
Bump packaging versions to 2.2.1

### DIFF
--- a/_service
+++ b/_service
@@ -3,6 +3,6 @@
     <param name="host">github.com</param>
     <param name="protocol">https</param>
     <param name="path">/RealOrangeKun/fetch/archive/refs/heads/main.tar.gz</param>
-    <param name="filename">fetch-2.2.0.tar.gz</param>
+    <param name="filename">fetch-2.2.1.tar.gz</param>
   </service>
 </services>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fetch (2.2.1) noble; urgency=medium
+
+  * Update to 2.2.1.
+
+ -- Youssef Tarek <amazingritro66@gmail.com>  Fri, 24 Jul 2026 21:44:30 +0300
+
 fetch (2.2.0.1) noble; urgency=medium
 
   * Fix Homepage field in debian/control to point at the upstream repo.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fetch (2.2.0.1) noble; urgency=medium
+
+  * Fix Homepage field in debian/control to point at the upstream repo.
+
+ -- Youssef Tarek <amazingritro66@gmail.com>  Fri, 24 Jul 2026 18:08:01 +0300
+
 fetch (2.2.0) noble; urgency=medium
 
   * Initial Debian/Ubuntu packaging.

--- a/fetch.spec
+++ b/fetch.spec
@@ -1,6 +1,6 @@
 Name:           fetch
 Version:        2.2.1
-Release:        1.%(date +%%Y%%m%%d%%H%%M)%{?dist}
+Release:        1.%(date +%%Y%%m%%d)%{?dist}
 Summary:        Animated 3D fetch tool for your terminal
 
 License:        ISC

--- a/fetch.spec
+++ b/fetch.spec
@@ -1,5 +1,5 @@
 Name:           fetch
-Version:        2.2.0
+Version:        2.2.1
 Release:        1.%(date +%%Y%%m%%d%%H%%M)%{?dist}
 Summary:        Animated 3D fetch tool for your terminal
 
@@ -32,6 +32,9 @@ config — no external dependencies required.
 %{_bindir}/fetch
 
 %changelog
+* Fri Jul 24 2026 Youssef Tarek <amazingritro66@gmail.com> - 2.2.1-1
+- Update to 2.2.1
+
 * Wed Jul 22 2026 Youssef Tarek <amazingritro66@gmail.com> - 2.2.0-1
 - Update to 2.2.0
 


### PR DESCRIPTION
## Summary
- Adds a new `debian/changelog` entry (2.2.0.1) for the `debian/control` Homepage fix from #43, since Launchpad needs a distinct version to re-upload and rebuild the PPA package.
- Bumps `fetch.spec` (shared by Fedora COPR and openSUSE OBS) and `debian/changelog` to 2.2.1, matching the upstream 2.2.1 release.