### PR TITLE
fix xbps package count

### DIFF
--- a/fetch.c
+++ b/fetch.c
@@ -1352,9 +1352,12 @@ static void gather_packages(void) {
   }
   // xbps (Void)
   if (!val[0]) {
-    n = count_subdirs("/var/db/xbps");
-    if (n > 0)
-      snprintf(val, sizeof(val), "%d (xbps)", n);
+    FILE *fp = popen("xbps-query -l 2>/dev/null | wc -l", "r");
+    if (fp) {
+      if (fscanf(fp, "%d", &n) == 1 && n > 0)
+        snprintf(val, sizeof(val), "%d (xbps)", n);
+      pclose(fp);
+    }
   }
   // apk (Alpine)
   if (!val[0]) {


### PR DESCRIPTION
Package detection for XBPS right now just counts subdirectories. Since the path contains metadata files rather than a dir per package it ends up returning an unrelated number instead of the actual installed package count.

This fixes that by using `popen` to query `xbps-query -l | wc -l` and reading the package count directly. I went with the subshell approach as it matches how the RPM detection is already handled. A pure C parsing approach for the versioned `pkgdb-*.plist` database file gets a bit bulky.

Let me know if you prefer using subshells here, as I couldn't find a clean way to reuse any of the existing helper functions for a pure C solution.