### PR TITLE
[chore] removed duplicate version help text

### DIFF
--- a/fetch.c
+++ b/fetch.c
@@ -3159,8 +3159,7 @@ int main(int argc, char **argv) {
           "    box=<0/1>                Draw a border box around the info block\n\n"
           "Logo: ~/.config/fetch/logo.txt\n"
           "  Custom ASCII/Unicode logo. Add '# distro: <name>' as the\n"
-          "  first line to set the color scheme.\n"
-          "  -V, --version             Show version\n");
+          "  first line to set the color scheme.\n");
       return 0;
     } else if (strcmp(argv[i], "--version") == 0 || strcmp(argv[i], "-V") == 0) {
       printf("fetch %s \"%s\" (%s, %s)\n", FETCH_VERSION, FETCH_CODENAME,


### PR DESCRIPTION
Very small thing, but there was still an artifact left from the various merges, namely a duplicate line of help text for --version.
* Removed the duplicate `-V, --version` in the help text