### PR TITLE
Error out when a flag needs a value but none is given

### DIFF
--- a/fetch.c
+++ b/fetch.c
@@ -3165,8 +3165,11 @@ int main(int argc, char **argv) {
       printf("fetch %s \"%s\" (%s, %s)\n", FETCH_VERSION, FETCH_CODENAME,
              FETCH_ARCH, FETCH_OS);
       return 0;
-    } else if ((strcmp(argv[i], "--logo") == 0 || strcmp(argv[i], "-l") == 0) &&
-               i + 1 < argc) {
+    } else if (strcmp(argv[i], "--logo") == 0 || strcmp(argv[i], "-l") == 0) {
+      if (i + 1 >= argc) {
+        fprintf(stderr, "fetch: option '%s' requires an argument\n", argv[i]);
+        return 1;
+      }
       logo_name = argv[++i];
     } else if (strcmp(argv[i], "--rotate-x") == 0) {
       rotate_x = 1;
@@ -3174,33 +3177,59 @@ int main(int argc, char **argv) {
     } else if (strcmp(argv[i], "--rotate-y") == 0) {
       rotate_x = 0;
       rotate_y = 1;
-    } else if ((strcmp(argv[i], "--speed") == 0 ||
-                strcmp(argv[i], "-s") == 0) &&
-               i + 1 < argc) {
+    } else if (strcmp(argv[i], "--speed") == 0 || strcmp(argv[i], "-s") == 0) {
+      if (i + 1 >= argc) {
+        fprintf(stderr, "fetch: option '%s' requires an argument\n", argv[i]);
+        return 1;
+      }
       speed = atof(argv[++i]);
     } else if (strcmp(argv[i], "--no-info") == 0) {
       show_info = 0;
     } else if (strcmp(argv[i], "--no-color") == 0) {
       use_color = 0;
-    } else if (strcmp(argv[i], "--frames") == 0 && i + 1 < argc) {
+    } else if (strcmp(argv[i], "--frames") == 0) {
+      if (i + 1 >= argc) {
+        fprintf(stderr, "fetch: option '%s' requires an argument\n", argv[i]);
+        return 1;
+      }
       max_frames = atoi(argv[++i]);
     } else if (strcmp(argv[i], "--infinite") == 0) {
       max_frames = 0;
-    } else if (strcmp(argv[i], "--shading-chars") == 0 && i + 1 < argc) {
+    } else if (strcmp(argv[i], "--shading-chars") == 0) {
+      if (i + 1 >= argc) {
+        fprintf(stderr, "fetch: option '%s' requires an argument\n", argv[i]);
+        return 1;
+      }
       shading = argv[++i];
-    } else if (strcmp(argv[i], "--shading-mode") == 0 && i + 1 < argc) {
+    } else if (strcmp(argv[i], "--shading-mode") == 0) {
+      if (i + 1 >= argc) {
+        fprintf(stderr, "fetch: option '%s' requires an argument\n", argv[i]);
+        return 1;
+      }
       shading_mode = argv[++i];
-    } else if (strcmp(argv[i], "--height") == 0 && i + 1 < argc) {
+    } else if (strcmp(argv[i], "--height") == 0) {
+      if (i + 1 >= argc) {
+        fprintf(stderr, "fetch: option '%s' requires an argument\n", argv[i]);
+        return 1;
+      }
       config_height = atoi(argv[++i]);
       if (config_height > MAX_HEIGHT)
         config_height = MAX_HEIGHT;
-    } else if (strcmp(argv[i], "--size") == 0 && i + 1 < argc) {
+    } else if (strcmp(argv[i], "--size") == 0) {
+      if (i + 1 >= argc) {
+        fprintf(stderr, "fetch: option '%s' requires an argument\n", argv[i]);
+        return 1;
+      }
       size_scale = atof(argv[++i]);
       if (size_scale < 0.5f)
         size_scale = 0.5f;
       if (size_scale > 5.0f)
         size_scale = 5.0f;
-    } else if (strcmp(argv[i], "--depth") == 0 && i + 1 < argc) {
+    } else if (strcmp(argv[i], "--depth") == 0) {
+      if (i + 1 >= argc) {
+        fprintf(stderr, "fetch: option '%s' requires an argument\n", argv[i]);
+        return 1;
+      }
       config_depth = atof(argv[++i]);
       if (config_depth < 0.1f)
         config_depth = 0.1f;


### PR DESCRIPTION
Right now flags that take a value, like --logo, --speed, --frames, --shading-chars, --shading-mode, --height, --size and --depth, are only matched when an argument actually follows them. If you run one with no value, say `fetch --logo` at the end of the command, it falls straight through to the unknown option branch instead of telling you what's actually wrong. That gives a misleading "unknown option" message for a flag that does exist, it's just missing its value.

This checks the flag name first, then verifies an argument follows, and prints a clear "requires an argument" error if it doesn't. Every affected flag behaves the same way now, and the existing unknown-option handling is untouched.

## Test plan
- Built with make and confirmed `fetch --logo`, `fetch --speed`, `fetch --frames`, `fetch --shading-chars`, `fetch --shading-mode`, `fetch --height`, `fetch --size`, and `fetch --depth` each print the requires-an-argument message and exit 1 when run with no value
- Confirmed `fetch --foo` still hits the existing unknown option message
- Confirmed normal usage with values still works as before