### PR TITLE
Fix package manager label from dnf to rpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ All system info is gathered natively – no fastfetch or neofetch needed:
 - **Memory/Swap** - `/proc/meminfo` (Linux), `vm_stat` (macOS)
 - **Disk** - `statvfs()` + `/proc/mounts` (Linux), `getmntinfo` (macOS) – supports multiple mount points via config
 - **Battery** - `energy_now/energy_full` (Linux), IOKit (macOS)
-- **Packages** - emerge, pacman, dpkg, rpm/dnf, xbps, apk, flatpak, brew
+- **Packages** - emerge, pacman, dpkg, rpm, xbps, apk, flatpak, brew
 - **Local IP** - `getifaddrs()`
 
 Stats like memory, battery, and uptime update in real-time while the logo spins.

--- a/fetch.c
+++ b/fetch.c
@@ -1466,7 +1466,7 @@ static void gather_packages(void) {
     if (n > 0)
       snprintf(val, sizeof(val), "%d (dpkg)", n);
   }
-  // rpm/dnf (Fedora, RHEL, openSUSE, etc.)
+  // rpm (Fedora, RHEL, openSUSE, etc.)
   if (!val[0]) {
     FILE *fp = popen("rpm -qa 2>/dev/null", "r");
     if (fp) {
@@ -1476,7 +1476,7 @@ static void gather_packages(void) {
         n++;
       pclose(fp);
       if (n > 0)
-        snprintf(val, sizeof(val), "%d (dnf)", n);
+        snprintf(val, sizeof(val), "%d (rpm)", n);
     }
   }
   // xbps (Void)


### PR DESCRIPTION
## Summary
- The package count field used `rpm -qa` to count installed packages but labeled the result `(dnf)`, which is misleading on rpm-based distros that don't use dnf (e.g. openSUSE uses zypper). Changed the label to `(rpm)`, the packaging format, matching the term used by other fetch tools like fastfetch.
- Updated the README's Packages field description to match.

Fixes #60

## Test plan
- [x] `make` builds cleanly