### PR TITLE
[Chore] Fix GPU name of integrated graphics (on AMD hardware)

### DIFF
--- a/fetch.c
+++ b/fetch.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #include <time.h>
 #include <limits.h>
+#include <ctype.h>
 
 #ifdef __APPLE__
 #include <sys/sysctl.h>
@@ -1950,13 +1951,33 @@ static int gpu_lookup_lspci(const char *pci_id, char *out, int outlen) {
     char *rev = strstr(line, " (rev ");
     if (rev)
       *rev = '\0';
+
     char *lb = strrchr(line, '[');
     char *rb = strrchr(line, ']');
     const char *name = NULL;
-    if (lb && rb && rb > lb) {
+
+    // AMD's lspci strings always wrap the vendor tag in brackets
+    // (e.g. "[AMD/ATI]"); discrete cards additionally wrap the product
+    // name in a second pair ("[Radeon RX 9070 XT]"), but some iGPUs only
+    // have the single vendor bracket. Blindly taking the last bracket
+    // pair picks up "AMD/ATI" in that case, so count brackets first.
+    int bracket_count = 0;
+    for (char *pp = line; *pp; pp++)
+      if (*pp == '[')
+        bracket_count++;
+
+    if (bracket_count >= 2 && lb && rb && rb > lb) {
       *rb = '\0';
       name = lb + 1;
-    } else {
+    } else if (lb && rb && rb > lb) {
+      char *after = rb + 1;
+      while (*after == ' ')
+        after++;
+      if (*after)
+        name = after;
+    }
+
+    if (!name) {
       char *corp = strstr(line, " Corporation ");
       int skip = corp ? 13 : 0;
       if (!corp) {
@@ -1979,6 +2000,7 @@ static int gpu_lookup_lspci(const char *pci_id, char *out, int outlen) {
       while (*name == ' ')
         name++;
     }
+
     if (name && *name) {
       strncpy(out, name, outlen - 1);
       out[outlen - 1] = '\0';
@@ -1987,6 +2009,35 @@ static int gpu_lookup_lspci(const char *pci_id, char *out, int outlen) {
   }
   pclose(fp);
   return ok;
+}
+
+static int str_ci_contains(const char *haystack, const char *needle) {
+  size_t hlen = strlen(haystack), nlen = strlen(needle);
+  if (nlen == 0 || nlen > hlen)
+    return 0;
+  for (size_t i = 0; i + nlen <= hlen; i++) {
+    size_t j = 0;
+    while (j < nlen &&
+           tolower((unsigned char)haystack[i + j]) ==
+               tolower((unsigned char)needle[j]))
+      j++;
+    if (j == nlen)
+      return 1;
+  }
+  return 0;
+}
+
+static int amd_name_is_igpu(const char *name) {
+  static const char *codenames[] = {
+      "Raphael",     "Phoenix",     "Phoenix2",  "Hawk Point",
+      "Renoir",      "Cezanne",     "Rembrandt", "Picasso",
+      "Raven",       "Raven2",      "Van Gogh",  "Mendocino",
+      "Barcelo",     "Strix Point", "Strix Halo", "Krackan Point",
+      NULL};
+  for (int i = 0; codenames[i]; i++)
+    if (str_ci_contains(name, codenames[i]))
+      return 1;
+  return 0;
 }
 #endif
 
@@ -2110,14 +2161,19 @@ static void gather_gpu(void) {
         type = "Integrated";
       else if (!strcmp(driver, "nvidia") || !strcmp(driver, "nouveau"))
         type = "Discrete";
+      else if (!strcmp(driver, "amdgpu"))
+        type = amd_name_is_igpu(name) ? "Integrated" : "Discrete";
     }
 
     if (!name[0])
       continue;
-    if (type[0])
-      add_info("GPU", "%s [%s]", name, type);
-    else
+    if (type[0]) {
+      char label[32];
+      snprintf(label, sizeof(label), "GPU [%s]", type);
+      add_info(label, "%s", name);
+    } else {
       add_info("GPU", "%s", name);
+    }
   }
   closedir(d);
 #endif

--- a/fetch.c
+++ b/fetch.c
@@ -2183,13 +2183,10 @@ static void gather_gpu(void) {
 
     if (!name[0])
       continue;
-    if (type[0]) {
-      char label[32];
-      snprintf(label, sizeof(label), "GPU [%s]", type);
-      add_info(label, "%s", name);
-    } else {
+    if (type[0])
+      add_info("GPU", "%s [%s]", name, type);
+    else
       add_info("GPU", "%s", name);
-    }
   }
   closedir(d);
 #endif


### PR DESCRIPTION
## Fix GPU name parsing and add Integrated/Discrete labeling

### Problem

`gather_gpu()` had two issues on multi-GPU AMD systems (APU + discrete card):

1. **Duplicate/wrong names.** `gpu_lookup_lspci()` always took the *last*
   bracket pair in `lspci` output as the product name. This works for
   discrete cards, whose `lspci` line has two bracket pairs (vendor tag +
   product name), but some AMD iGPUs only have one bracket pair (just the
   vendor tag). On those, the code was picking up `AMD/ATI` as the "product
   name" instead of skipping past it, so an APU + discrete AMD GPU could
   both show up as `AMD Graphics`, indistinguishable from each other.

2. **No integrated/discrete distinction.** The type-classification block
   only handled Intel (`i915`/`xe`) and Nvidia (`nvidia`/`nouveau`) drivers.
   AMD's `amdgpu` driver covers both APU and discrete silicon, so it was
   never classified either way, even once the name parsing was fixed.

### What changed

- **`gpu_lookup_lspci()`** now counts bracket pairs before trusting the last
  one as the product name. If there are two or more, it behaves as before.
  If there's only one (the vendor tag), it skips past that bracket and uses
  whatever text follows instead, correctly resolving AMD iGPU codenames
  like `Raphael` instead of misreading `AMD/ATI`.
- **`amd_name_is_igpu()`** (new) checks the resolved GPU name against a list
  of known AMD APU codenames (Raphael, Phoenix, Cezanne, Rembrandt, Strix
  Point, etc.) to classify `amdgpu`-driven devices as integrated or
  discrete. A PCI-bus-number heuristic was tried first but turned out
  unreliable on platforms with multiple PCIe root complexes (e.g. AM5),
  where an iGPU can enumerate on a nonzero bus, the codename list is a
  known, finite set and doesn't have that problem.
- **Type classification** extended to cover `amdgpu` alongside the existing
  Intel/Nvidia checks.
- **Display format** unchanged from the existing convention, type is still
  appended after the name as `GPU: <name> [<type>]`, consistent with how
  other fields (e.g. Disk, Memory) already show bracketed metadata.

### Example output

Before:
```
GPU: Radeon RX 9070/9070 XT/9070 GRE
GPU: AMD/ATI
```

After:
```
GPU: Radeon RX 9070/9070 XT/9070 GRE [Discrete]
GPU: Raphael [Integrated]
```

### Notes

- Intel and Nvidia classification logic is unchanged, this only adds a
  branch for `amdgpu`.
- Systems with only one GPU, or where `lspci` isn't installed at all, fall
  back to the same generic driver-based naming as before (`AMD Graphics`,
  `Intel Graphics`, `NVIDIA GPU`) with no type suffix, so there's no
  regression for the common single-GPU case.
- Requires `pciutils` (`lspci`) to be installed for accurate product names;
  without it, GPUs still show but with generic driver-based names as before.

### Screenshot

<img width="1361" height="562" alt="image" src="https://github.com/user-attachments/assets/e8bef477-2310-4dca-a7f8-2a090c17babd" />