### PR TITLE
[Bug fix] Fix gather_shell function to retrieve correct version

### DIFF
--- a/fetch.c
+++ b/fetch.c
@@ -1599,20 +1599,12 @@ static void gather_shell(void) {
   if (fp) {
     char buf[256];
     if (fgets(buf, sizeof(buf), fp)) {
-      // Extract version number from first line
-      // e.g. "zsh 5.9.0.3-test (aarch64...)" or "bash 5.2.26(1)-release"
-      // Find the version part after the shell name
-      char *ver = strstr(buf, name);
-      if (ver) {
-        ver += strlen(name);
-        while (*ver == ' ')
-          ver++;
-      } else {
-        // Try to find first digit
-        ver = buf;
-        while (*ver && !(*ver >= '0' && *ver <= '9'))
-          ver++;
-      }
+      // Find the first digit, more reliable than searching past the
+      // shell name, since some shells put a comma right after the name
+      // (e.g. fish: "fish, version 4.8.1", bash: "GNU bash, version 5.2.26...")
+      char *ver = buf;
+      while (*ver && !(*ver >= '0' && *ver <= '9'))
+        ver++;
       if (*ver) {
         int len = 0;
         while (ver[len] && ver[len] != ' ' && ver[len] != '(' &&


### PR DESCRIPTION
This pull request updates the logic for extracting the shell version in the `gather_shell` function in `fetch.c`. The main improvement is making the version extraction more robust by searching for the first digit in the version string, rather than relying on the shell name, which can be unreliable due to formatting differences across shells.

**Shell version extraction improvements:**

* Changed the version extraction logic to scan for the first digit in the output string, making it more reliable for different shell formats (e.g., `fish`, `bash`, etc.) instead of searching after the shell name.

**Tested with:**
* Bash
* Zsh
* Fish
* Nushell

**Before:**
`Shell: fish ,`

**After:**
`Shell: fish 4.8.1`