### PR TITLE
[Feat] Nix package manager addition to gather_packages

### DIFF
--- a/fetch.c
+++ b/fetch.c
@@ -1515,18 +1515,10 @@ static void gather_packages(void) {
     if (n > 0)
       snprintf(val, sizeof(val), "%d (apk)", n);
   }
+#endif
+  
   // Nix (NixOS, or Nix package manager on other distros).
-  // Uses direct references (one entry per package a profile links
-  // together), not full closure, closure size massively overcounts
-  // since it includes every transitive shared library.
-  //
-  // Home-manager profiles have an extra layer of indirection:
-  // /etc/profiles/per-user/$USER resolves to a "user-environment"
-  // derivation that itself only references a single "home-manager-path"
-  // derivation, which is the actual buildEnv joining all your packages.
-  // So the user-profile count needs one extra reference-resolution hop
-  // that the system profile doesn't.
-  if (!val[0]) {
+  {
     const char *home = getenv("HOME");
     char base[128] = "";
     if (home) {
@@ -1535,23 +1527,43 @@ static void gather_packages(void) {
       strncpy(base, b, sizeof(base) - 1);
     }
 
-    char cmd[600];
-    snprintf(cmd, sizeof(cmd),
-      "sh -c '"
-      "sys=$(nix-store -q --references /run/current-system/sw 2>/dev/null | wc -l); "
-      "resolved=$(readlink -f /etc/profiles/per-user/%s 2>/dev/null); "
-      "if [ -n \"$resolved\" ]; then "
-      "  hop1=$(nix-store -q --references \"$resolved\" 2>/dev/null); "
-      "  if [ -n \"$hop1\" ]; then "
-      "    usr=$(nix-store -q --references \"$hop1\" 2>/dev/null | wc -l); "
-      "  else "
-      "    usr=$(nix-store -q --references \"$resolved\" 2>/dev/null | wc -l); "
-      "  fi; "
-      "else "
-      "  usr=0; "
-      "fi; "
-      "echo \"$sys $usr\"'",
-      base);
+    // Only allow a username charset before it's interpolated
+    // into a shell command, reject anything else rather than trying to
+    // escape it.
+    int base_valid = base[0] != '\0';
+    for (int i = 0; base_valid && base[i]; i++) {
+      char c = base[i];
+      if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-'))
+        base_valid = 0;
+    }
+    if (!base_valid)
+      base[0] = '\0';
+
+    char cmd[700];
+    if (base[0]) {
+      snprintf(cmd, sizeof(cmd),
+        "sh -c '"
+        "sys=$(nix-store -q --references /run/current-system/sw 2>/dev/null | wc -l); "
+        "resolved=$(readlink -f /etc/profiles/per-user/%s 2>/dev/null); "
+        "if [ -n \"$resolved\" ]; then "
+        "  hop1=$(nix-store -q --references \"$resolved\" 2>/dev/null); "
+        "  if [ -n \"$hop1\" ]; then "
+        "    usr=$(nix-store -q --references \"$hop1\" 2>/dev/null | wc -l); "
+        "  else "
+        "    usr=$(nix-store -q --references \"$resolved\" 2>/dev/null | wc -l); "
+        "  fi; "
+        "else "
+        "  usr=0; "
+        "fi; "
+        "echo \"$sys $usr\"'",
+        base);
+    } else {
+      snprintf(cmd, sizeof(cmd),
+        "sh -c '"
+        "sys=$(nix-store -q --references /run/current-system/sw 2>/dev/null | wc -l); "
+        "echo \"$sys 0\"'");
+    }
 
     int nix_system = 0, nix_user = 0;
     FILE *fp = popen(cmd, "r");
@@ -1563,14 +1575,21 @@ static void gather_packages(void) {
       pclose(fp);
     }
 
+    char nix_val[64] = "";
     if (nix_system > 0 && nix_user > 0)
-      snprintf(val, sizeof(val), "%d (system), %d (user)", nix_system, nix_user);
+      snprintf(nix_val, sizeof(nix_val), "%d (system), %d (user)", nix_system, nix_user);
     else if (nix_system > 0)
-      snprintf(val, sizeof(val), "%d (system)", nix_system);
+      snprintf(nix_val, sizeof(nix_val), "%d (system)", nix_system);
     else if (nix_user > 0)
-      snprintf(val, sizeof(val), "%d (user)", nix_user);
+      snprintf(nix_val, sizeof(nix_val), "%d (user)", nix_user);
+
+    if (nix_val[0]) {
+      if (val[0])
+        snprintf(val + strlen(val), sizeof(val) - strlen(val), ", %s", nix_val);
+      else
+        snprintf(val, sizeof(val), "%s", nix_val);
+    }
   }
-#endif
 
   n = 0;
   FILE *flatpak_fp = popen("flatpak list --columns=ref 2>/dev/null", "r");

--- a/fetch.c
+++ b/fetch.c
@@ -1523,7 +1523,7 @@ static void gather_packages(void) {
   // derivation, which is the actual buildEnv joining all your packages.
   // So the user-profile count needs one extra reference-resolution hop
   // that the system profile doesn't.
-  {
+  if (!val[0]) {
     char cmd[400], buf[256];
     FILE *fp;
 
@@ -1556,7 +1556,6 @@ static void gather_packages(void) {
       }
 
       if (resolved[0]) {
-        // First hop: user-environment -> home-manager-path
         char hop1[512] = "";
         snprintf(cmd, sizeof(cmd),
                  "nix-store -q --references %s 2>/dev/null", resolved);
@@ -1572,7 +1571,6 @@ static void gather_packages(void) {
         }
 
         if (hop1[0]) {
-          // Second hop: home-manager-path -> actual package references
           snprintf(cmd, sizeof(cmd),
                    "nix-store -q --references %s 2>/dev/null | wc -l", hop1);
           fp = popen(cmd, "r");
@@ -1582,8 +1580,6 @@ static void gather_packages(void) {
             pclose(fp);
           }
         } else {
-          // No extra indirection (plain nix-env style profile) — count
-          // references directly on the resolved path.
           snprintf(cmd, sizeof(cmd),
                    "nix-store -q --references %s 2>/dev/null | wc -l", resolved);
           fp = popen(cmd, "r");
@@ -1596,20 +1592,12 @@ static void gather_packages(void) {
       }
     }
 
-    char nix_val[64] = "";
     if (nix_system > 0 && nix_user > 0)
-      snprintf(nix_val, sizeof(nix_val), "%d (system), %d (user)", nix_system, nix_user);
+      snprintf(val, sizeof(val), "%d (system), %d (user)", nix_system, nix_user);
     else if (nix_system > 0)
-      snprintf(nix_val, sizeof(nix_val), "%d (system)", nix_system);
+      snprintf(val, sizeof(val), "%d (system)", nix_system);
     else if (nix_user > 0)
-      snprintf(nix_val, sizeof(nix_val), "%d (user)", nix_user);
-
-    if (nix_val[0]) {
-      if (val[0])
-        snprintf(val + strlen(val), sizeof(val) - strlen(val), ", %s", nix_val);
-      else
-        snprintf(val, sizeof(val), "%s", nix_val);
-    }
+      snprintf(val, sizeof(val), "%d (user)", nix_user);
   }
 #endif
 

--- a/fetch.c
+++ b/fetch.c
@@ -1512,62 +1512,98 @@ static void gather_packages(void) {
     if (n > 0)
       snprintf(val, sizeof(val), "%d (apk)", n);
   }
-  // Nix (NixOS, or Nix package manager on other distros)
+  // Nix (NixOS, or Nix package manager on other distros).
+  // Uses direct references (one entry per package a profile links
+  // together), not full closure, closure size massively overcounts
+  // since it includes every transitive shared library.
+  //
+  // Home-manager profiles have an extra layer of indirection:
+  // /etc/profiles/per-user/$USER resolves to a "user-environment"
+  // derivation that itself only references a single "home-manager-path"
+  // derivation, which is the actual buildEnv joining all your packages.
+  // So the user-profile count needs one extra reference-resolution hop
+  // that the system profile doesn't.
   {
-    const struct { const char *path; const char *label; } nix_profiles[] = {
-        {"/run/current-system/sw", "system"},
-        {"/nix/var/nix/profiles/default", "default"},
-        {NULL, NULL},
-    };
-    char home_profile[256] = "";
-    const char *home = getenv("HOME");
-    if (home) {
-      snprintf(home_profile, sizeof(home_profile), "%s/.nix-profile", home);
+    char cmd[400], buf[256];
+    FILE *fp;
+
+    int nix_system = 0;
+    fp = popen("nix-store -q --references /run/current-system/sw 2>/dev/null | wc -l", "r");
+    if (fp) {
+      if (fscanf(fp, "%d", &nix_system) != 1)
+        nix_system = 0;
+      pclose(fp);
     }
 
-    char nix_val[128] = "";
-    for (int i = 0; nix_profiles[i].path; i++) {
-      char cmd[300];
-      snprintf(cmd, sizeof(cmd), "nix-store -qR %s 2>/dev/null | wc -l",
-               nix_profiles[i].path);
-      FILE *fp = popen(cmd, "r");
-      if (!fp)
-        continue;
-      int count = 0;
-      if (fscanf(fp, "%d", &count) != 1)
-        count = 0;
-      pclose(fp);
-      if (count > 0) {
-        char part[48];
-        snprintf(part, sizeof(part), "%d (%s)", count, nix_profiles[i].label);
-        if (nix_val[0])
-          snprintf(nix_val + strlen(nix_val), sizeof(nix_val) - strlen(nix_val),
-                   ", %s", part);
-        else
-          snprintf(nix_val, sizeof(nix_val), "%s", part);
-      }
-    }
-    if (home_profile[0]) {
-      char cmd[300];
-      snprintf(cmd, sizeof(cmd), "nix-store -qR %s 2>/dev/null | wc -l",
-               home_profile);
-      FILE *fp = popen(cmd, "r");
+    int nix_user = 0;
+    const char *home = getenv("HOME");
+    if (home) {
+      const char *base = strrchr(home, '/');
+      base = base ? base + 1 : home;
+
+      char resolved[512] = "";
+      snprintf(cmd, sizeof(cmd),
+               "readlink -f /etc/profiles/per-user/%s 2>/dev/null", base);
+      fp = popen(cmd, "r");
       if (fp) {
-        int count = 0;
-        if (fscanf(fp, "%d", &count) != 1)
-          count = 0;
+        if (fgets(buf, sizeof(buf), fp)) {
+          int len = strlen(buf);
+          while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r'))
+            buf[--len] = '\0';
+          strncpy(resolved, buf, sizeof(resolved) - 1);
+        }
         pclose(fp);
-        if (count > 0) {
-          char part[48];
-          snprintf(part, sizeof(part), "%d (user)", count);
-          if (nix_val[0])
-            snprintf(nix_val + strlen(nix_val), sizeof(nix_val) - strlen(nix_val),
-                     ", %s", part);
-          else
-            snprintf(nix_val, sizeof(nix_val), "%s", part);
+      }
+
+      if (resolved[0]) {
+        // First hop: user-environment -> home-manager-path
+        char hop1[512] = "";
+        snprintf(cmd, sizeof(cmd),
+                 "nix-store -q --references %s 2>/dev/null", resolved);
+        fp = popen(cmd, "r");
+        if (fp) {
+          if (fgets(buf, sizeof(buf), fp)) {
+            int len = strlen(buf);
+            while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r'))
+              buf[--len] = '\0';
+            strncpy(hop1, buf, sizeof(hop1) - 1);
+          }
+          pclose(fp);
+        }
+
+        if (hop1[0]) {
+          // Second hop: home-manager-path -> actual package references
+          snprintf(cmd, sizeof(cmd),
+                   "nix-store -q --references %s 2>/dev/null | wc -l", hop1);
+          fp = popen(cmd, "r");
+          if (fp) {
+            if (fscanf(fp, "%d", &nix_user) != 1)
+              nix_user = 0;
+            pclose(fp);
+          }
+        } else {
+          // No extra indirection (plain nix-env style profile) — count
+          // references directly on the resolved path.
+          snprintf(cmd, sizeof(cmd),
+                   "nix-store -q --references %s 2>/dev/null | wc -l", resolved);
+          fp = popen(cmd, "r");
+          if (fp) {
+            if (fscanf(fp, "%d", &nix_user) != 1)
+              nix_user = 0;
+            pclose(fp);
+          }
         }
       }
     }
+
+    char nix_val[64] = "";
+    if (nix_system > 0 && nix_user > 0)
+      snprintf(nix_val, sizeof(nix_val), "%d (system), %d (user)", nix_system, nix_user);
+    else if (nix_system > 0)
+      snprintf(nix_val, sizeof(nix_val), "%d (system)", nix_system);
+    else if (nix_user > 0)
+      snprintf(nix_val, sizeof(nix_val), "%d (user)", nix_user);
+
     if (nix_val[0]) {
       if (val[0])
         snprintf(val + strlen(val), sizeof(val) - strlen(val), ", %s", nix_val);

--- a/fetch.c
+++ b/fetch.c
@@ -1512,6 +1512,69 @@ static void gather_packages(void) {
     if (n > 0)
       snprintf(val, sizeof(val), "%d (apk)", n);
   }
+  // Nix (NixOS, or Nix package manager on other distros)
+  {
+    const struct { const char *path; const char *label; } nix_profiles[] = {
+        {"/run/current-system/sw", "system"},
+        {"/nix/var/nix/profiles/default", "default"},
+        {NULL, NULL},
+    };
+    char home_profile[256] = "";
+    const char *home = getenv("HOME");
+    if (home) {
+      snprintf(home_profile, sizeof(home_profile), "%s/.nix-profile", home);
+    }
+
+    char nix_val[128] = "";
+    for (int i = 0; nix_profiles[i].path; i++) {
+      char cmd[300];
+      snprintf(cmd, sizeof(cmd), "nix-store -qR %s 2>/dev/null | wc -l",
+               nix_profiles[i].path);
+      FILE *fp = popen(cmd, "r");
+      if (!fp)
+        continue;
+      int count = 0;
+      if (fscanf(fp, "%d", &count) != 1)
+        count = 0;
+      pclose(fp);
+      if (count > 0) {
+        char part[48];
+        snprintf(part, sizeof(part), "%d (%s)", count, nix_profiles[i].label);
+        if (nix_val[0])
+          snprintf(nix_val + strlen(nix_val), sizeof(nix_val) - strlen(nix_val),
+                   ", %s", part);
+        else
+          snprintf(nix_val, sizeof(nix_val), "%s", part);
+      }
+    }
+    if (home_profile[0]) {
+      char cmd[300];
+      snprintf(cmd, sizeof(cmd), "nix-store -qR %s 2>/dev/null | wc -l",
+               home_profile);
+      FILE *fp = popen(cmd, "r");
+      if (fp) {
+        int count = 0;
+        if (fscanf(fp, "%d", &count) != 1)
+          count = 0;
+        pclose(fp);
+        if (count > 0) {
+          char part[48];
+          snprintf(part, sizeof(part), "%d (user)", count);
+          if (nix_val[0])
+            snprintf(nix_val + strlen(nix_val), sizeof(nix_val) - strlen(nix_val),
+                     ", %s", part);
+          else
+            snprintf(nix_val, sizeof(nix_val), "%s", part);
+        }
+      }
+    }
+    if (nix_val[0]) {
+      if (val[0])
+        snprintf(val + strlen(val), sizeof(val) - strlen(val), ", %s", nix_val);
+      else
+        snprintf(val, sizeof(val), "%s", nix_val);
+    }
+  }
 #endif
 
   n = 0;

--- a/fetch.c
+++ b/fetch.c
@@ -1524,72 +1524,40 @@ static void gather_packages(void) {
   // So the user-profile count needs one extra reference-resolution hop
   // that the system profile doesn't.
   if (!val[0]) {
-    char cmd[400], buf[256];
-    FILE *fp;
-
-    int nix_system = 0;
-    fp = popen("nix-store -q --references /run/current-system/sw 2>/dev/null | wc -l", "r");
-    if (fp) {
-      if (fscanf(fp, "%d", &nix_system) != 1)
-        nix_system = 0;
-      pclose(fp);
+    const char *home = getenv("HOME");
+    char base[128] = "";
+    if (home) {
+      const char *b = strrchr(home, '/');
+      b = b ? b + 1 : home;
+      strncpy(base, b, sizeof(base) - 1);
     }
 
-    int nix_user = 0;
-    const char *home = getenv("HOME");
-    if (home) {
-      const char *base = strrchr(home, '/');
-      base = base ? base + 1 : home;
+    char cmd[600];
+    snprintf(cmd, sizeof(cmd),
+      "sh -c '"
+      "sys=$(nix-store -q --references /run/current-system/sw 2>/dev/null | wc -l); "
+      "resolved=$(readlink -f /etc/profiles/per-user/%s 2>/dev/null); "
+      "if [ -n \"$resolved\" ]; then "
+      "  hop1=$(nix-store -q --references \"$resolved\" 2>/dev/null); "
+      "  if [ -n \"$hop1\" ]; then "
+      "    usr=$(nix-store -q --references \"$hop1\" 2>/dev/null | wc -l); "
+      "  else "
+      "    usr=$(nix-store -q --references \"$resolved\" 2>/dev/null | wc -l); "
+      "  fi; "
+      "else "
+      "  usr=0; "
+      "fi; "
+      "echo \"$sys $usr\"'",
+      base);
 
-      char resolved[512] = "";
-      snprintf(cmd, sizeof(cmd),
-               "readlink -f /etc/profiles/per-user/%s 2>/dev/null", base);
-      fp = popen(cmd, "r");
-      if (fp) {
-        if (fgets(buf, sizeof(buf), fp)) {
-          int len = strlen(buf);
-          while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r'))
-            buf[--len] = '\0';
-          strncpy(resolved, buf, sizeof(resolved) - 1);
-        }
-        pclose(fp);
+    int nix_system = 0, nix_user = 0;
+    FILE *fp = popen(cmd, "r");
+    if (fp) {
+      if (fscanf(fp, "%d %d", &nix_system, &nix_user) != 2) {
+        nix_system = 0;
+        nix_user = 0;
       }
-
-      if (resolved[0]) {
-        char hop1[512] = "";
-        snprintf(cmd, sizeof(cmd),
-                 "nix-store -q --references %s 2>/dev/null", resolved);
-        fp = popen(cmd, "r");
-        if (fp) {
-          if (fgets(buf, sizeof(buf), fp)) {
-            int len = strlen(buf);
-            while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r'))
-              buf[--len] = '\0';
-            strncpy(hop1, buf, sizeof(hop1) - 1);
-          }
-          pclose(fp);
-        }
-
-        if (hop1[0]) {
-          snprintf(cmd, sizeof(cmd),
-                   "nix-store -q --references %s 2>/dev/null | wc -l", hop1);
-          fp = popen(cmd, "r");
-          if (fp) {
-            if (fscanf(fp, "%d", &nix_user) != 1)
-              nix_user = 0;
-            pclose(fp);
-          }
-        } else {
-          snprintf(cmd, sizeof(cmd),
-                   "nix-store -q --references %s 2>/dev/null | wc -l", resolved);
-          fp = popen(cmd, "r");
-          if (fp) {
-            if (fscanf(fp, "%d", &nix_user) != 1)
-              nix_user = 0;
-            pclose(fp);
-          }
-        }
-      }
+      pclose(fp);
     }
 
     if (nix_system > 0 && nix_user > 0)


### PR DESCRIPTION
This pull request adds support for detecting and reporting the number of installed Nix packages (for both system and user profiles) in the `gather_packages` function in `fetch.c`. This allows the tool to display accurate package counts on NixOS and systems using the Nix package manager, handling the unique way Nix tracks packages for both system and user environments.

**Nix package support:**

* Added logic to detect and count system packages by querying references from `/run/current-system/sw` using `nix-store`, and to count user packages by resolving the user's profile and traversing home-manager indirection if present. The results are displayed as system and/or user package counts.
* Handles the extra reference-resolution hop needed for home-manager user profiles, ensuring accurate user package counts on systems using home-manager.

The displayed number should represent user-installed packages and not the actual amount of packages on the user's system. I.e. only packages directly inside the home-manager and configuration nix files should be present and not all of their implicit and dependent packages.

Edit: 
Here is what the actual output looks like:
```bash
Packages: 232 (system), 88 (user), 10 (flatpak)
```