### PR TITLE
Add Cursor field, reading GTK cursor theme name and size on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ All system info is gathered natively – no fastfetch or neofetch needed:
 - **Display** - per-connector DRM enumeration (multi-monitor)
 - **WM** - process scanning + DE-to-WM mapping
 - **Theme/Icons/Font** - `~/.config/gtk-3.0/settings.ini` (Linux), `defaults read` (macOS)
+- **Cursor** - `~/.config/gtk-3.0/settings.ini` (Linux only)
 - **CPU** - `/proc/cpuinfo`, device-tree (Apple Silicon), or `sysctl` (macOS)
 - **GPU** - DRM + `lspci` for full names (Linux), `system_profiler` (macOS)
 - **Memory/Swap** - `/proc/meminfo` (Linux), `vm_stat` (macOS)
@@ -202,6 +203,7 @@ wm
 theme
 icons
 font
+cursor
 terminal
 cpu
 gpu

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,7 @@ wm
 theme
 icons
 font
+cursor
 terminal
 cpu
 gpu

--- a/fetch.c
+++ b/fetch.c
@@ -858,6 +858,7 @@ enum {
   F_THEME,
   F_ICONS,
   F_FONT,
+  F_CURSOR,
   F_TERMINAL,
   F_CPU,
   F_GPU,
@@ -912,6 +913,7 @@ static const struct {
                  {"theme", F_THEME},
                  {"icons", F_ICONS},
                  {"font", F_FONT},
+                 {"cursor", F_CURSOR},
                  {"terminal", F_TERMINAL},
                  {"cpu", F_CPU},
                  {"gpu", F_GPU},
@@ -927,9 +929,10 @@ static const struct {
 static void config_defaults(void) {
   // Default order
   int defaults[] = {
-      F_OS,     F_HOST,  F_KERNEL, F_UPTIME, F_PACKAGES, F_SHELL,  F_DISPLAY,
-      F_WM,     F_THEME, F_ICONS,  F_FONT,   F_TERMINAL, F_CPU,    F_GPU,
-      F_MEMORY, F_SWAP,  F_DISK,   F_IP,     F_BATTERY,  F_LOCALE, F_COLORS};
+      F_OS,     F_HOST,  F_KERNEL, F_UPTIME,  F_PACKAGES, F_SHELL,    F_DISPLAY,
+      F_WM,     F_THEME, F_ICONS,  F_FONT,    F_CURSOR,   F_TERMINAL, F_CPU,
+      F_GPU,    F_MEMORY, F_SWAP,  F_DISK,    F_IP,       F_BATTERY,  F_LOCALE,
+      F_COLORS};
   field_count = sizeof(defaults) / sizeof(defaults[0]);
   for (int i = 0; i < field_count; i++) {
     field_order[i] = defaults[i];
@@ -2859,6 +2862,21 @@ static void gather_font(void) {
 #endif
 }
 
+static void gather_cursor(void) {
+#ifndef __APPLE__
+  char cursor[64] = "";
+  read_gtk_setting("gtk-cursor-theme-name", cursor, sizeof(cursor));
+  if (cursor[0]) {
+    char size[16] = "";
+    read_gtk_setting("gtk-cursor-theme-size", size, sizeof(size));
+    if (size[0])
+      add_info("Cursor", "%s (%spx)", cursor, size);
+    else
+      add_info("Cursor", "%s", cursor);
+  }
+#endif
+}
+
 // Render buffers, one entry per sub-cell: z-buffer (0 = empty), luminance, color
 #define SUB_H (MAX_HEIGHT * MAX_SUB_ROWS)
 #define SUB_W (ANIM_WIDTH * MAX_SUB_COLS)
@@ -3319,7 +3337,7 @@ int main(int argc, char **argv) {
           "  Comment out or remove fields to hide them.\n"
           "  Available fields:\n"
           "    os, host, kernel, uptime, packages, shell, display, wm,\n"
-          "    theme, icons, font, terminal, cpu, gpu, memory, swap,\n"
+          "    theme, icons, font, cursor, terminal, cpu, gpu, memory, swap,\n"
           "    disk, ip, battery, locale, colors\n\n"
           "  Extra disks:\n"
           "    disk=/home               Show additional mount point\n"
@@ -3511,6 +3529,7 @@ int main(int argc, char **argv) {
       [F_THEME] = gather_theme,
       [F_ICONS] = gather_icons,
       [F_FONT] = gather_font,
+      [F_CURSOR] = gather_cursor,
       [F_TERMINAL] = gather_terminal,
       [F_CPU] = gather_cpu,
       [F_GPU] = gather_gpu,


### PR DESCRIPTION
## Summary

Adds a new Cursor info field that reads the active GTK cursor theme name and size on Linux, so it can be shown alongside the other system info fields.

## Test plan

- Built with make and ran ./fetch to confirm the new field renders correctly
- Verified it can be toggled via the config like the other fields