### PR TITLE
Display refresh rate and monitor details, Qt/GTK2 theme info, CPU and battery fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ All system info is gathered natively – no fastfetch or neofetch needed:
 - **GPU** - DRM + `lspci` for full names (Linux), `system_profiler` (macOS)
 - **Memory/Swap** - `/proc/meminfo` (Linux), `vm_stat` (macOS)
 - **Disk** - `statvfs()` + `/proc/mounts` (Linux), `getmntinfo` (macOS) – supports multiple mount points via config
-- **Battery** - `energy_now/energy_full` (Linux), IOKit (macOS)
+- **Battery** - `energy_now/energy_full` plus `model_name` (Linux), IOKit (macOS)
 - **Packages** - emerge, pacman, dpkg, rpm, xbps, apk, flatpak, brew
 - **Local IP** - `getifaddrs()`
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ All system info is gathered natively – no fastfetch or neofetch needed:
 - **Uptime** - `/proc/uptime`
 - **Packages** - emerge, pacman, dpkg, rpm, xbps, apk
 - **Shell** - parent process detection (not just `$SHELL`)
-- **Display** - per-connector DRM enumeration (multi-monitor)
+- **Display** - per-connector DRM enumeration (multi-monitor): active resolution and refresh rate from the CRTC mode, monitor name and physical size from EDID, built-in vs external
 - **WM** - process scanning + DE-to-WM mapping
 - **Theme/Icons/Font** - `~/.config/gtk-3.0/settings.ini` (Linux), `defaults read` (macOS)
 - **Cursor** - `~/.config/gtk-3.0/settings.ini` (Linux only)

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ All system info is gathered natively – no fastfetch or neofetch needed:
 - **Shell** - parent process detection (not just `$SHELL`)
 - **Display** - per-connector DRM enumeration (multi-monitor): active resolution and refresh rate from the CRTC mode, monitor name and physical size from EDID, built-in vs external
 - **WM** - process scanning + DE-to-WM mapping
-- **Theme/Icons/Font** - `~/.config/gtk-3.0/settings.ini` (Linux), `defaults read` (macOS)
+- **Theme/Icons/Font** - `~/.config/gtk-3.0/settings.ini`, `~/.gtkrc-2.0`, and Qt (`qt6ct`/`qt5ct`, `~/.config/kdeglobals`) on Linux, `defaults read` (macOS)
 - **Cursor** - `~/.config/gtk-3.0/settings.ini` (Linux only)
 - **CPU** - `/proc/cpuinfo`, device-tree (Apple Silicon), or `sysctl` (macOS)
 - **GPU** - DRM + `lspci` for full names (Linux), `system_profiler` (macOS)

--- a/fetch.c
+++ b/fetch.c
@@ -2208,6 +2208,9 @@ static void gather_cpu(void) {
           if (len > 0 && len < (int)sizeof(name)) {
             memcpy(name, val, len);
             name[len] = '\0';
+            char *at = strstr(name, " @ ");
+            if (at)
+              *at = '\0';
           }
         }
       }

--- a/fetch.c
+++ b/fetch.c
@@ -1,5 +1,7 @@
 #include <dirent.h>
+#include <fcntl.h>
 #include <math.h>
+#include <stdint.h>
 #include <poll.h>
 #include <signal.h>
 #include <stdarg.h>
@@ -1712,6 +1714,189 @@ static void gather_shell(void) {
     add_info("Shell", "%s", name);
 }
 
+#ifndef __APPLE__
+struct drm_modeinfo_min {
+  uint32_t clock;
+  uint16_t hdisplay, hsync_start, hsync_end, htotal, hskew;
+  uint16_t vdisplay, vsync_start, vsync_end, vtotal, vscan;
+  uint32_t vrefresh;
+  uint32_t flags;
+  uint32_t type;
+  char name[32];
+};
+
+struct drm_crtc_min {
+  uint64_t set_connectors_ptr;
+  uint32_t count_connectors;
+  uint32_t crtc_id;
+  uint32_t fb_id;
+  uint32_t x, y;
+  uint32_t gamma_size;
+  uint32_t mode_valid;
+  struct drm_modeinfo_min mode;
+};
+
+struct drm_encoder_min {
+  uint32_t encoder_id;
+  uint32_t encoder_type;
+  uint32_t crtc_id;
+  uint32_t possible_crtcs;
+  uint32_t possible_clones;
+};
+
+struct drm_connector_min {
+  uint64_t encoders_ptr, modes_ptr, props_ptr, prop_values_ptr;
+  uint32_t count_modes, count_props, count_encoders;
+  uint32_t encoder_id, connector_id;
+  uint32_t connector_type, connector_type_id;
+  uint32_t connection;
+  uint32_t mm_width, mm_height;
+  uint32_t subpixel;
+  uint32_t pad;
+};
+
+#define DRM_MIN_GETCRTC _IOWR('d', 0xA1, struct drm_crtc_min)
+#define DRM_MIN_GETENCODER _IOWR('d', 0xA6, struct drm_encoder_min)
+#define DRM_MIN_GETCONNECTOR _IOWR('d', 0xA7, struct drm_connector_min)
+
+static int drm_active_mode(const char *card, uint32_t conn_id, int *w, int *h,
+                           float *hz, int *mm_w, int *mm_h) {
+  char dev[64];
+  snprintf(dev, sizeof(dev), "/dev/dri/%s", card);
+  int fd = open(dev, O_RDONLY | O_CLOEXEC);
+  if (fd < 0)
+    return 0;
+
+  struct drm_connector_min conn;
+  memset(&conn, 0, sizeof(conn));
+  conn.connector_id = conn_id;
+  struct drm_modeinfo_min scratch;
+  conn.modes_ptr = (uint64_t)(uintptr_t)&scratch;
+  conn.count_modes = 1;
+  int got = 0;
+  if (ioctl(fd, DRM_MIN_GETCONNECTOR, &conn) == 0) {
+    if (conn.mm_width && conn.mm_height) {
+      *mm_w = (int)conn.mm_width;
+      *mm_h = (int)conn.mm_height;
+    }
+    struct drm_encoder_min enc;
+    memset(&enc, 0, sizeof(enc));
+    enc.encoder_id = conn.encoder_id;
+    if (conn.encoder_id && ioctl(fd, DRM_MIN_GETENCODER, &enc) == 0 &&
+        enc.crtc_id) {
+      struct drm_crtc_min crtc;
+      memset(&crtc, 0, sizeof(crtc));
+      crtc.crtc_id = enc.crtc_id;
+      if (ioctl(fd, DRM_MIN_GETCRTC, &crtc) == 0 && crtc.mode_valid &&
+          crtc.mode.htotal && crtc.mode.vtotal) {
+        *w = crtc.mode.hdisplay;
+        *h = crtc.mode.vdisplay;
+        float r = crtc.mode.clock * 1000.0f /
+                  ((float)crtc.mode.htotal * (float)crtc.mode.vtotal);
+        if (crtc.mode.flags & 0x10)
+          r *= 2.0f;
+        if (crtc.mode.flags & 0x20)
+          r /= 2.0f;
+        if (crtc.mode.vscan > 1)
+          r /= (float)crtc.mode.vscan;
+        *hz = r;
+        got = 1;
+      }
+    }
+  }
+  close(fd);
+  return got;
+}
+
+static int read_edid(const char *conn_dir, unsigned char *edid, size_t max) {
+  char path[320];
+  snprintf(path, sizeof(path), "/sys/class/drm/%s/edid", conn_dir);
+  FILE *fp = fopen(path, "rb");
+  if (!fp)
+    return 0;
+  size_t n = fread(edid, 1, max, fp);
+  fclose(fp);
+  if (n < 128)
+    return 0;
+  static const unsigned char hdr[8] = {0x00, 0xFF, 0xFF, 0xFF,
+                                       0xFF, 0xFF, 0xFF, 0x00};
+  return memcmp(edid, hdr, 8) == 0;
+}
+
+static void edid_name(const unsigned char *e, char *out, size_t outsz) {
+  out[0] = '\0';
+  for (int i = 54; i <= 108; i += 18) {
+    const unsigned char *d = e + i;
+    if (d[0] || d[1] || d[2] || d[3] != 0xFC)
+      continue;
+    size_t n = 0;
+    for (int j = 5; j < 18 && n + 1 < outsz; j++) {
+      if (d[j] == 0x0A)
+        break;
+      out[n++] = (char)d[j];
+    }
+    while (n > 0 && out[n - 1] == ' ')
+      n--;
+    out[n] = '\0';
+    if (out[0])
+      return;
+  }
+  unsigned v = ((unsigned)e[8] << 8) | e[9];
+  char m[4] = {(char)('A' + ((v >> 10) & 0x1F) - 1),
+               (char)('A' + ((v >> 5) & 0x1F) - 1),
+               (char)('A' + (v & 0x1F) - 1), '\0'};
+  for (int i = 0; i < 3; i++)
+    if (m[i] < 'A' || m[i] > 'Z')
+      return;
+  snprintf(out, outsz, "%s%02X%02X", m, e[11], e[10]);
+}
+
+static void edid_size_mm(const unsigned char *e, int *w, int *h) {
+  const unsigned char *d = e + 54;
+  if (d[0] || d[1]) {
+    int mw = d[12] | ((d[14] & 0xF0) << 4);
+    int mh = d[13] | ((d[14] & 0x0F) << 8);
+    if (mw > 0 && mh > 0) {
+      *w = mw;
+      *h = mh;
+      return;
+    }
+  }
+  if (e[21] && e[22]) {
+    *w = e[21] * 10;
+    *h = e[22] * 10;
+  }
+}
+
+static float edid_refresh(const unsigned char *e) {
+  const unsigned char *d = e + 54;
+  unsigned clock = d[0] | ((unsigned)d[1] << 8);
+  if (!clock)
+    return 0;
+  unsigned htotal = (d[2] | ((d[4] & 0xF0) << 4)) + (d[3] | ((d[4] & 0x0F) << 8));
+  unsigned vtotal = (d[5] | ((d[7] & 0xF0) << 4)) + (d[6] | ((d[7] & 0x0F) << 8));
+  if (!htotal || !vtotal)
+    return 0;
+  return clock * 10000.0f / (float)(htotal * vtotal);
+}
+
+static void format_hz(float hz, char *out, size_t outsz) {
+  if (hz <= 0.0f) {
+    out[0] = '\0';
+    return;
+  }
+  if (fabsf(hz - roundf(hz)) < 0.05f)
+    snprintf(out, outsz, "%.0f Hz", hz);
+  else
+    snprintf(out, outsz, "%.2f Hz", hz);
+}
+
+static int connector_is_internal(const char *conn) {
+  return strncmp(conn, "eDP", 3) == 0 || strncmp(conn, "LVDS", 4) == 0 ||
+         strncmp(conn, "DSI", 3) == 0;
+}
+#endif
+
 static void gather_display(void) {
 #ifdef __APPLE__
   FILE *fp = popen("system_profiler SPDisplaysDataType 2>/dev/null", "r");
@@ -1766,7 +1951,7 @@ static void gather_display(void) {
     if (!dash)
       continue;
 
-    char path[256];
+    char path[320];
     snprintf(path, sizeof(path), "/sys/class/drm/%s/status", ent->d_name);
     FILE *fp = fopen(path, "r");
     if (!fp)
@@ -1795,7 +1980,61 @@ static void gather_display(void) {
     if (!mode[0])
       continue;
 
-    add_info("Display", "%s @ %s", dash + 1, mode);
+    const char *conn = dash + 1;
+    char card[32];
+    size_t card_len = (size_t)(dash - ent->d_name);
+    if (card_len >= sizeof(card))
+      continue;
+    memcpy(card, ent->d_name, card_len);
+    card[card_len] = '\0';
+
+    unsigned char edid[256];
+    int have_edid = read_edid(ent->d_name, edid, sizeof(edid));
+
+    int w = 0, h = 0, mm_w = 0, mm_h = 0;
+    float hz = 0.0f;
+    unsigned conn_id = 0;
+    snprintf(path, sizeof(path), "/sys/class/drm/%s/connector_id",
+             ent->d_name);
+    fp = fopen(path, "r");
+    if (fp) {
+      if (fscanf(fp, "%u", &conn_id) != 1)
+        conn_id = 0;
+      fclose(fp);
+    }
+    if (conn_id)
+      drm_active_mode(card, conn_id, &w, &h, &hz, &mm_w, &mm_h);
+
+    if (hz <= 0.0f && have_edid)
+      hz = edid_refresh(edid);
+    if ((!mm_w || !mm_h) && have_edid)
+      edid_size_mm(edid, &mm_w, &mm_h);
+
+    char res[32];
+    if (w > 0 && h > 0)
+      snprintf(res, sizeof(res), "%dx%d", w, h);
+    else
+      snprintf(res, sizeof(res), "%s", mode);
+
+    char label[80];
+    char name[32] = "";
+    if (have_edid)
+      edid_name(edid, name, sizeof(name));
+    snprintf(label, sizeof(label), "Display (%s)", name[0] ? name : conn);
+
+    char inches[16] = "";
+    if (mm_w > 0 && mm_h > 0) {
+      int diag = (int)lroundf(
+          sqrtf((float)(mm_w * mm_w + mm_h * mm_h)) / 25.4f);
+      if (diag > 0)
+        snprintf(inches, sizeof(inches), " in %d\"", diag);
+    }
+    char rate[32];
+    format_hz(hz, rate, sizeof(rate));
+    const char *sep = rate[0] ? (inches[0] ? ", " : " @ ") : "";
+
+    add_info(label, "%s%s%s%s [%s]", res, inches, sep, rate,
+             connector_is_internal(conn) ? "Built-in" : "External");
     emitted++;
   }
   closedir(d);
@@ -1807,7 +2046,7 @@ static void gather_display(void) {
     while ((ent = readdir(d))) {
       if (strncmp(ent->d_name, "card", 4) != 0)
         continue;
-      char path[256];
+      char path[320];
       snprintf(path, sizeof(path), "/sys/class/drm/%s/modes", ent->d_name);
       FILE *fp = fopen(path, "r");
       if (!fp)

--- a/fetch.c
+++ b/fetch.c
@@ -2856,15 +2856,40 @@ static void gather_battery(void) {
     }
   }
 
+  char model[64] = "";
+  snprintf(path, sizeof(path), "/sys/class/power_supply/%s/model_name",
+           bat_name);
+  fp = fopen(path, "r");
+  if (!fp) {
+    snprintf(path, sizeof(path), "/sys/class/power_supply/%s/manufacturer",
+             bat_name);
+    fp = fopen(path, "r");
+  }
+  if (fp) {
+    if (fgets(model, sizeof(model), fp)) {
+      int len = strlen(model);
+      while (len > 0 && (model[len - 1] == '\n' || model[len - 1] == '\r' ||
+                         model[len - 1] == ' '))
+        model[--len] = '\0';
+    }
+    fclose(fp);
+  }
+
+  char label[80];
+  if (model[0])
+    snprintf(label, sizeof(label), "Battery (%s)", model);
+  else
+    snprintf(label, sizeof(label), "Battery");
+
   if (capacity >= 0) {
     const char *color = capacity >= 50 ? "32" : capacity >= 20 ? "93" : "31";
     if (time_str[0] && status[0])
-      add_info("Battery", "\033[%sm%d%%\033[0m (%s) [%s]", color, capacity,
+      add_info(label, "\033[%sm%d%%\033[0m (%s) [%s]", color, capacity,
                time_str, status);
     else if (status[0])
-      add_info("Battery", "\033[%sm%d%%\033[0m [%s]", color, capacity, status);
+      add_info(label, "\033[%sm%d%%\033[0m [%s]", color, capacity, status);
     else
-      add_info("Battery", "\033[%sm%d%%\033[0m", color, capacity);
+      add_info(label, "\033[%sm%d%%\033[0m", color, capacity);
   }
 #endif
 }

--- a/fetch.c
+++ b/fetch.c
@@ -3127,30 +3127,176 @@ static void gather_locale(void) {
     add_info("Locale", "%s", lang);
 }
 
-static void read_gtk_setting(const char *key, char *out, int maxlen) {
-  char path[512];
-  const char *home = getenv("HOME");
-  if (!home)
-    return;
-  snprintf(path, sizeof(path), "%s/.config/gtk-3.0/settings.ini", home);
+static int read_ini_key(const char *path, const char *section, const char *key,
+                        char *out, int maxlen) {
   FILE *fp = fopen(path, "r");
   if (!fp)
-    return;
-  char buf[256];
-  int keylen = strlen(key);
+    return 0;
+  char buf[512];
+  size_t keylen = strlen(key);
+  size_t seclen = section ? strlen(section) : 0;
+  int in_section = section ? 0 : 1;
+  int found = 0;
   while (fgets(buf, sizeof(buf), fp)) {
-    if (strncmp(buf, key, keylen) == 0 && buf[keylen] == '=') {
-      char *val = buf + keylen + 1;
-      int len = strlen(val);
-      while (len > 0 && (val[len - 1] == '\n' || val[len - 1] == '\r'))
-        val[--len] = '\0';
-      if (len > 0 && len < maxlen) {
-        memcpy(out, val, len + 1);
-      }
-      break;
+    char *line = buf;
+    while (*line == ' ' || *line == '\t')
+      line++;
+    int len = strlen(line);
+    while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r' ||
+                       line[len - 1] == ' ' || line[len - 1] == '\t'))
+      line[--len] = '\0';
+    if (line[0] == '[') {
+      if (section)
+        in_section = strncmp(line + 1, section, seclen) == 0 &&
+                     line[1 + seclen] == ']';
+      continue;
     }
+    if (!in_section || strncmp(line, key, keylen) != 0)
+      continue;
+    char *val = line + keylen;
+    while (*val == ' ' || *val == '\t')
+      val++;
+    if (*val != '=')
+      continue;
+    val++;
+    while (*val == ' ' || *val == '\t')
+      val++;
+    int vlen = strlen(val);
+    if (vlen >= 2 && ((val[0] == '"' && val[vlen - 1] == '"') ||
+                      (val[0] == '\'' && val[vlen - 1] == '\''))) {
+      val[vlen - 1] = '\0';
+      val++;
+      vlen -= 2;
+    }
+    if (vlen > 0 && vlen < maxlen) {
+      memcpy(out, val, vlen + 1);
+      found = 1;
+    }
+    break;
   }
   fclose(fp);
+  return found;
+}
+
+static int read_gtk3_setting(const char *key, char *out, int maxlen) {
+  const char *home = getenv("HOME");
+  if (!home)
+    return 0;
+  char path[512];
+  snprintf(path, sizeof(path), "%s/.config/gtk-3.0/settings.ini", home);
+  return read_ini_key(path, NULL, key, out, maxlen);
+}
+
+static int read_gtk2_setting(const char *key, char *out, int maxlen) {
+  const char *home = getenv("HOME");
+  if (!home)
+    return 0;
+  char path[512];
+  snprintf(path, sizeof(path), "%s/.gtkrc-2.0", home);
+  if (read_ini_key(path, NULL, key, out, maxlen))
+    return 1;
+  snprintf(path, sizeof(path), "%s/.config/gtk-2.0/gtkrc", home);
+  return read_ini_key(path, NULL, key, out, maxlen);
+}
+
+static void read_gtk_setting(const char *key, char *out, int maxlen) {
+  read_gtk3_setting(key, out, maxlen);
+}
+
+static int qtct_conf_path(char *out, size_t outsz) {
+  const char *home = getenv("HOME");
+  if (!home)
+    return 0;
+  static const char *variants[] = {"qt6ct/qt6ct.conf", "qt5ct/qt5ct.conf",
+                                   NULL};
+  const char *platform = getenv("QT_QPA_PLATFORMTHEME");
+  if (platform && strncmp(platform, "qt", 2) == 0) {
+    snprintf(out, outsz, "%s/.config/%s/%s.conf", home, platform, platform);
+    if (access(out, R_OK) == 0)
+      return 1;
+  }
+  for (int i = 0; variants[i]; i++) {
+    snprintf(out, outsz, "%s/.config/%s", home, variants[i]);
+    if (access(out, R_OK) == 0)
+      return 1;
+  }
+  return 0;
+}
+
+static int read_kdeglobals(const char *section, const char *key, char *out,
+                           int maxlen) {
+  const char *home = getenv("HOME");
+  if (!home)
+    return 0;
+  char path[512];
+  snprintf(path, sizeof(path), "%s/.config/kdeglobals", home);
+  return read_ini_key(path, section, key, out, maxlen);
+}
+
+static void qt_theme(char *out, int maxlen) {
+  char path[512];
+  if (qtct_conf_path(path, sizeof(path)) &&
+      read_ini_key(path, "Appearance", "style", out, maxlen) && out[0])
+    return;
+  if (read_kdeglobals("KDE", "widgetStyle", out, maxlen) && strstr(out, "ct-style"))
+    out[0] = '\0';
+}
+
+static void qt_icons(char *out, int maxlen) {
+  char path[512];
+  if (qtct_conf_path(path, sizeof(path)) &&
+      read_ini_key(path, "Appearance", "icon_theme", out, maxlen) && out[0])
+    return;
+  read_kdeglobals("Icons", "Theme", out, maxlen);
+}
+
+static void font_pt_format(char *font, size_t fontsz) {
+  char *last = strrchr(font, ' ');
+  if (!last || !last[1])
+    return;
+  for (const char *p = last + 1; *p; p++)
+    if (*p < '0' || *p > '9')
+      return;
+  char size[16];
+  snprintf(size, sizeof(size), "%s", last + 1);
+  size_t room = fontsz - (size_t)(last - font);
+  snprintf(last, room, " (%spt)", size);
+}
+
+static void qt_font(char *out, int maxlen) {
+  char path[512];
+  char raw[192] = "";
+  if (!qtct_conf_path(path, sizeof(path)))
+    return;
+  if (!read_ini_key(path, "Fonts", "general", raw, sizeof(raw)) || !raw[0])
+    return;
+  char *comma = strchr(raw, ',');
+  if (!comma)
+    return;
+  *comma = '\0';
+  char *size = comma + 1;
+  char *end = strchr(size, ',');
+  if (end)
+    *end = '\0';
+  snprintf(out, maxlen, "%s (%spt)", raw, size);
+}
+
+static void append_tagged(char *dst, size_t dstsz, const char *val,
+                          const char *tag) {
+  if (!val[0])
+    return;
+  size_t n = strlen(dst);
+  snprintf(dst + n, dstsz - n, "%s%s [%s]", n ? ", " : "", val, tag);
+}
+
+static void append_gtk_pair(char *dst, size_t dstsz, const char *gtk2,
+                            const char *gtk3) {
+  if (gtk2[0] && gtk3[0] && strcmp(gtk2, gtk3) == 0) {
+    append_tagged(dst, dstsz, gtk3, "GTK2/3");
+    return;
+  }
+  append_tagged(dst, dstsz, gtk2, "GTK2");
+  append_tagged(dst, dstsz, gtk3, "GTK3");
 }
 
 static void gather_theme(void) {
@@ -3169,10 +3315,14 @@ static void gather_theme(void) {
   else
     add_info("Theme", "Light");
 #else
-  char theme[64] = "";
-  read_gtk_setting("gtk-theme-name", theme, sizeof(theme));
-  if (theme[0])
-    add_info("Theme", "%s [GTK3]", theme);
+  char qt[64] = "", gtk2[64] = "", gtk3[64] = "", out[256] = "";
+  qt_theme(qt, sizeof(qt));
+  read_gtk2_setting("gtk-theme-name", gtk2, sizeof(gtk2));
+  read_gtk3_setting("gtk-theme-name", gtk3, sizeof(gtk3));
+  append_tagged(out, sizeof(out), qt, "Qt");
+  append_gtk_pair(out, sizeof(out), gtk2, gtk3);
+  if (out[0])
+    add_info("Theme", "%s", out);
 #endif
 }
 
@@ -3180,10 +3330,14 @@ static void gather_icons(void) {
 #ifdef __APPLE__
   add_info("Icons", "System");
 #else
-  char icons[64] = "";
-  read_gtk_setting("gtk-icon-theme-name", icons, sizeof(icons));
-  if (icons[0])
-    add_info("Icons", "%s [GTK3]", icons);
+  char qt[64] = "", gtk2[64] = "", gtk3[64] = "", out[256] = "";
+  qt_icons(qt, sizeof(qt));
+  read_gtk2_setting("gtk-icon-theme-name", gtk2, sizeof(gtk2));
+  read_gtk3_setting("gtk-icon-theme-name", gtk3, sizeof(gtk3));
+  append_tagged(out, sizeof(out), qt, "Qt");
+  append_gtk_pair(out, sizeof(out), gtk2, gtk3);
+  if (out[0])
+    add_info("Icons", "%s", out);
 #endif
 }
 
@@ -3201,10 +3355,16 @@ static void gather_font(void) {
   if (font[0])
     add_info("Font", "%s", font);
 #else
-  char font[128] = "";
-  read_gtk_setting("gtk-font-name", font, sizeof(font));
-  if (font[0])
-    add_info("Font", "%s [GTK3]", font);
+  char qt[128] = "", gtk2[128] = "", gtk3[128] = "", out[448] = "";
+  qt_font(qt, sizeof(qt));
+  read_gtk2_setting("gtk-font-name", gtk2, sizeof(gtk2));
+  read_gtk3_setting("gtk-font-name", gtk3, sizeof(gtk3));
+  font_pt_format(gtk2, sizeof(gtk2));
+  font_pt_format(gtk3, sizeof(gtk3));
+  append_tagged(out, sizeof(out), qt, "Qt");
+  append_gtk_pair(out, sizeof(out), gtk2, gtk3);
+  if (out[0])
+    add_info("Font", "%s", out);
 #endif
 }
 


### PR DESCRIPTION
Four independent field improvements, one commit each, all Linux-side and all native reads (no shelling out to other fetch tools). Every commit builds on its own.

### Display: refresh rate, monitor name, physical size

`/sys/class/drm/*/modes` only lists the connector's preferred mode and carries no timing information, so there was no way to get a refresh rate out of it. This reads the mode actually programmed on the CRTC driving each connector (GETCONNECTOR/GETENCODER/GETCRTC) and computes the rate from the pixel clock and totals, with interlace/doublescan/vscan corrections. Name and physical size come from parsing the connector's EDID.

```
-Display: eDP-1 @ 1920x1080
+Display (AUOB49B): 1920x1080 in 15", 165 Hz [Built-in]
+Display (GM27X5IPS): 1920x1080 in 27", 180 Hz [External]
```

The DRM structs and ioctl numbers are declared locally instead of including `<drm/drm_mode.h>`, so the build still needs nothing but libm and no kernel headers. Struct sizes, field offsets and request numbers were verified against the real headers with static asserts; a mismatch on another kernel fails with ENOTTY and falls back rather than misbehaving. These are read-only ioctls that need no DRM master, only an openable card node (logind grants the active session an ACL). If the node cannot be opened, for instance over ssh, it falls back to the modes file for resolution and the EDID preferred timing for the rate; with no usable EDID it prints what it printed before.

### Theme/Icons/Font: Qt and GTK2

Only `~/.config/gtk-3.0/settings.ini` was read, so a configured Qt or GTK2 setup was invisible. Now reads qt6ct/qt5ct (honouring `QT_QPA_PLATFORMTHEME`) with `~/.config/kdeglobals` as fallback, plus `~/.gtkrc-2.0`. GTK2 and GTK3 collapse into one `GTK2/3` entry when they agree, split when they do not.

```
-Theme: adw-gtk3 [GTK3]
-Icons: Adwaita [GTK3]
-Font: JetBrainsMono Nerd Font Medium 11 [GTK3]
+Theme: Fusion [Qt], adw-gtk3 [GTK2/3]
+Icons: breeze-dark [Qt], Adwaita [GTK2/3]
+Font: JetBrainsMono Nerd Font (11pt) [Qt], JetBrainsMono Nerd Font Medium (11pt) [GTK2/3]
```

This needed a real ini reader, since the old helper matched a bare key at line start but GTK2 quotes its values and kdeglobals/qt6ct.conf use sections. `read_gtk_setting` stays as a thin wrapper for the Cursor field. A GTK3-only machine prints exactly what it printed before, with no stray separators or empty tags (verified with a synthetic `$HOME`).

### CPU: stop printing the frequency twice

Intel bakes the base clock into the model name in `/proc/cpuinfo`:

```
-CPU: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz (16) @ 4.60 GHz
+CPU: 11th Gen Intel(R) Core(TM) i7-11800H (16) @ 4.60 GHz
```

### Battery: model in the label

Multi-battery machines had no way to tell the rows apart, and the model is useful anyway. Reads `model_name`, falling back to `manufacturer`; batteries with neither keep the plain `Battery` label.

```
-Battery: 75% [Not charging]
+Battery (DELL M59JH19): 75% [Not charging]
```

### Testing

Manual, per the repo's usual approach: built and ran on Fedora 44, x86_64, niri/Wayland, with a built-in eDP panel and an external HDMI monitor, checking each changed field against the hardware. Also exercised the fallback paths (GTK3-only config, kdeglobals-only Qt config, EDID-derived refresh) with synthetic inputs.

`-Wall -Wextra` warnings go from 33 to 30: widening the path buffer in `gather_display` clears three pre-existing `snprintf` truncation warnings, and no new ones are introduced.
