### PR TITLE
[Feat] Added vendor to the Host entry

### DIFF
--- a/fetch.c
+++ b/fetch.c
@@ -1369,6 +1369,23 @@ static void gather_os(void) {
 #endif
 }
 
+// Reads the first line of a small pseudo-file (e.g. under /sys or /proc)
+// into out, trimming the trailing newline. Returns 1 on success, 0 if the
+// file couldn't be opened or was empty.
+static int try_read_first_line(const char *path, char *out, int outlen) {
+  out[0] = '\0';
+  FILE *fp = fopen(path, "r");
+  if (!fp)
+    return 0;
+  if (fgets(out, outlen, fp)) {
+    int len = strlen(out);
+    while (len > 0 && (out[len - 1] == '\n' || out[len - 1] == '\r'))
+      out[--len] = '\0';
+  }
+  fclose(fp);
+  return out[0] != '\0';
+}
+
 static void gather_host(void) {
 #ifdef __APPLE__
   char model[128] = "";

--- a/fetch.c
+++ b/fetch.c
@@ -1393,22 +1393,25 @@ static void gather_host(void) {
     add_info("Host", "%s", model);
 #else
   char model[128] = "";
+  char vendor[64] = "";
+
   // Try device-tree first (ARM/Apple Silicon), then DMI (x86)
-  FILE *fp = fopen("/proc/device-tree/model", "r");
-  if (!fp)
-    fp = fopen("/sys/class/dmi/id/product_name", "r");
-  if (fp) {
-    if (fgets(model, sizeof(model), fp)) {
-      int len = strlen(model);
-      while (len > 0 && (model[len - 1] == '\n' || model[len - 1] == '\r' ||
-                         model[len - 1] == '\0'))
-        len--;
-      model[len] = '\0';
-    }
-    fclose(fp);
+  if (!try_read_first_line("/proc/device-tree/model", model, sizeof(model))) {
+    if (try_read_first_line("/sys/class/dmi/id/product_name", model, sizeof(model)))
+      try_read_first_line("/sys/class/dmi/id/sys_vendor", vendor, sizeof(vendor));
   }
-  if (model[0])
-    add_info("Host", "%s", model);
+
+  // Some boards already embed the vendor name in product_name
+  // don't duplicate it if so.
+  if (vendor[0] && strncasecmp(model, vendor, strlen(vendor)) == 0)
+    vendor[0] = '\0';
+
+  if (model[0]) {
+    if (vendor[0])
+      add_info("Host", "%s %s", vendor, model);
+    else
+      add_info("Host", "%s", model);
+  }
 #endif
 }
 


### PR DESCRIPTION
I have added the vendor to the host entry because just having the model displayed felt awkward. I also feel like having the vendor displayed as well adds helpful information to the user.

Before:
```bash
Host: G5 KC
```

After:
```bash
Host: GIGABYTE G5 KC
```