### PR TITLE
Bump RPM and Debian packaging to 2.3.0

### DIFF
--- a/_service
+++ b/_service
@@ -3,6 +3,6 @@
     <param name="host">github.com</param>
     <param name="protocol">https</param>
     <param name="path">/RealOrangeKun/fetch/archive/refs/heads/main.tar.gz</param>
-    <param name="filename">fetch-2.2.1.tar.gz</param>
+    <param name="filename">fetch-2.3.0.tar.gz</param>
   </service>
 </services>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fetch (2.3.0) noble; urgency=medium
+
+  * Update to 2.3.0.
+
+ -- Youssef Tarek <amazingritro66@gmail.com>  Fri, 21 Aug 2026 23:11:10 +0300
+
 fetch (2.2.1) noble; urgency=medium
 
   * Update to 2.2.1.

--- a/fetch.spec
+++ b/fetch.spec
@@ -1,5 +1,5 @@
 Name:           fetch
-Version:        2.2.1
+Version:        2.3.0
 Release:        1.%(date +%%Y%%m%%d)%{?dist}
 Summary:        Animated 3D fetch tool for your terminal
 
@@ -32,6 +32,9 @@ config — no external dependencies required.
 %{_bindir}/fetch
 
 %changelog
+* Fri Aug 21 2026 Youssef Tarek <amazingritro66@gmail.com> - 2.3.0-1
+- Update to 2.3.0
+
 * Fri Jul 24 2026 Youssef Tarek <amazingritro66@gmail.com> - 2.2.1-1
 - Update to 2.2.1
 


### PR DESCRIPTION
Bumps `fetch.spec`, `debian/changelog` and `_service` to 2.3.0.